### PR TITLE
Fixed broken github links on employee details page

### DIFF
--- a/app/views/users/_github_profile.html.haml
+++ b/app/views/users/_github_profile.html.haml
@@ -1,4 +1,5 @@
 %ul.media-list
   - github_entries.each do |entry|
     .project-name
+      - entry.content.gsub!( %r{<a href=\"/},'<a href="https://github.com/')
       = raw entry.content


### PR DESCRIPTION
refs #93. The Github tab the employee details page shows the github activity feed. The links in the feed do not consist the domain and hence the links crash. Fixed the links by adding the domain to the links.