### PR TITLE
Fixed issue: blog feed not retrieved if blog feel url does't match format.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -442,7 +442,7 @@ GEM
     rest_client (1.8.3)
       netrc (~> 0.7.7)
     retriable (2.1.0)
-    rmagick (2.13.3)
+    rmagick (2.16.0)
     rnotifier (0.1.5)
       faraday (>= 0.8.7)
       multi_json (>= 1.7.2)
@@ -622,5 +622,8 @@ DEPENDENCIES
   unicorn
   whenever
 
+RUBY VERSION
+   ruby 2.2.4p230
+
 BUNDLED WITH
-   1.11.2
+   1.13.2

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -181,15 +181,15 @@ class UsersController < ApplicationController
 
     xml_feed = Feedjira::Feed.fetch_raw "https://github.com/#{handle}.atom"
 
-    if xml_feed.eql?(404) 
+    if xml_feed.eql?(404)
       @github_message = "The server has not found anything matching the URI given!!"
       return nil
     end
 
     github_feed = Feedjira::Feed.parse xml_feed
-    
+
     return nil if github_feed.try(:entries).try(:blank?)
-    
+
     if github_feed != 200
       github_commits = []
       github_feed.entries.each do |entry|
@@ -204,24 +204,24 @@ class UsersController < ApplicationController
   end
 
   def get_blog_feed
-    blog_url = @user.public_profile.blog_url
-    @blog_message = "#{@user.name} has not entered blog url yet!!" if blog_url.blank?
-   
-    return if blog_url.blank?
+    blog_feed_url = @user.public_profile.blog_feed_url
+    @blog_message = "#{@user.name} has not entered blog feel url yet!!" if blog_feed_url.blank?
 
-    xml_feed = Feedjira::Feed.fetch_raw "#{blog_url}/feed"
-    if xml_feed.eql?(0) 
+    return if blog_feed_url.blank?
+
+    xml_feed = Feedjira::Feed.fetch_raw blog_feed_url
+    if xml_feed.eql?(0)
       @blog_message = "The server has not found anything matching the URI given!!"
       return nil
     end
-    
+
     blog_feed = Feedjira::Feed.parse xml_feed
 
     return nil if blog_feed.try(:entries).try(:blank?)
     if blog_feed != 0
       blog_feed.entries[0..9]
     else
-      @blog_message = "No blog entries found for #{@user.name}!!" 
+      @blog_message = "No blog entries found for #{@user.name}!!"
       nil
     end
   end

--- a/app/models/public_profile.rb
+++ b/app/models/public_profile.rb
@@ -2,7 +2,7 @@ class PublicProfile
   include Mongoid::Document
   include Mongoid::Slug
 
-  mount_uploader :image, FileUploader 
+  mount_uploader :image, FileUploader
 
   field :first_name, default: ''
   field :last_name, default: ''
@@ -16,25 +16,26 @@ class PublicProfile
   field :github_handle
   field :twitter_handle
   field :blog_url
+  field :blog_feed_url, type: String
   field :image
 
   #validates_attachment :photo, :content_type => { :content_type => "image/jpg" }
 
   embedded_in :user
-  
+
   #validates_presence_of :first_name, :last_name, :gender, :mobile_number, :date_of_birth, :blood_group, :on => :update
   validates :gender, inclusion: { in: GENDER }, allow_blank: true, :on => :update
   validates :blood_group, inclusion: { in: BLOOD_GROUPS }, allow_blank: true, :on => :update
-    
+
   before_save do
     #We need to manually set the slug because user does not have field 'name' in its model and delegated to public_profile
     user.set_slug
     self.user.set_details("dob", self.date_of_birth) if self.date_of_birth_changed? #set the dob_day and dob_month
-    
+
   end
-  
+
   def name
-    "#{first_name} #{last_name}"  
+    "#{first_name} #{last_name}"
   end
 
 end

--- a/app/views/users/_public_profile.html.haml
+++ b/app/views/users/_public_profile.html.haml
@@ -20,6 +20,7 @@
   = pub.input :github_handle
   = pub.input :twitter_handle
   = pub.input :blog_url
+  = pub.input :blog_feed_url
   %center
     = pub.submit 'Update Profile', class: 'btn'
 :css

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -94,5 +94,18 @@ describe UsersController do
       expect(assigns(:blog_entries).count).to eq 10
     end
 
+    it 'should render message if no blog feed url is present' do
+      params = {"feed_type" => "blog", "id" => @user.id}
+      @user.public_profile.update({blog_feed_url: nil})
+      raw_response_file = File.new("spec/sample_feeds/blog_example_feed.xml")
+      allow(Feedjira::Feed).to receive(:fetch_raw).and_return(raw_response_file.read)
+
+      xhr :get, :get_feed, params
+      expect(assigns(:blog_message)).to eq "#{@user.name} has not entered blog feel url yet!!"
+
+      should respond_with(:success)
+      should render_template('users/get_feed')
+    end
+
   end
 end

--- a/spec/factories/public_profiles.rb
+++ b/spec/factories/public_profiles.rb
@@ -10,5 +10,6 @@ FactoryGirl.define do
     date_of_birth Date.today
     github_handle "abhishekbose87"
     blog_url "rishionrails.wordpress.com"
+    blog_feed_url "rishionrails.wordpress.com/feed"
   end
 end


### PR DESCRIPTION
ref #85 The blog feed url was assumed. If the actual feed url doesn't match the assumed url, then the blog feed wasnt loaded. Added field to public profile to allow user to specify the feed url explicitly.