### PR TITLE
Make joining date monditory

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -28,9 +28,8 @@ class UsersController < ApplicationController
     @user.attributes =  user_params
     if @user.save
       flash.notice = 'Profile updated Succesfully'
-      #UserMailer.delay.verification(@user.id)
     else
-      flash[:error] = "Error #{@user.errors.full_messages.join(' ')}"
+      flash[:error] = "Error #{@user.generate_errors_message}"
     end
     redirect_to public_profile_user_path(@user)
   end

--- a/app/models/private_profile.rb
+++ b/app/models/private_profile.rb
@@ -31,9 +31,12 @@ class PrivateProfile
   end
 
   def check_status_and_role?
-    if date_of_joining.blank? && (user.role == 'Employee' || user.role == 'HR') && user.status == 'approved'
-      return true
-    end
+    role = { employee: 'Employee', HR: 'HR' }
+    return true if date_of_joining.blank? &&
+                   (user.role == role[:employee] ||
+                   user.role == role[:HR]) &&
+                   user.status == STATUS[STATUS.find_index('approved')]
+
     return false
   end
   

--- a/app/models/private_profile.rb
+++ b/app/models/private_profile.rb
@@ -31,10 +31,9 @@ class PrivateProfile
   end
 
   def check_status_and_role?
-    role = { employee: 'Employee', HR: 'HR' }
     return true if date_of_joining.blank? &&
-                   (user.role == role[:employee] ||
-                   user.role == role[:HR]) &&
+                   (user.role == ROLE[:employee] ||
+                   user.role == ROLE[:HR]) &&
                    user.status == STATUS[STATUS.find_index('approved')]
 
     return false

--- a/app/models/private_profile.rb
+++ b/app/models/private_profile.rb
@@ -15,9 +15,11 @@ class PrivateProfile
   embeds_many :contact_persons
   has_many :addresses, autosave: true
 
+  validates :date_of_joining, presence: true, if: :check_status_and_role?, on: :update
+
   accepts_nested_attributes_for :addresses
   accepts_nested_attributes_for :contact_persons
-  
+
   before_save do
     if self.date_of_joining_changed?
       user = self.user
@@ -26,6 +28,13 @@ class PrivateProfile
         user.set_details("doj", self.date_of_joining)
       end
     end
+  end
+
+  def check_status_and_role?
+    if date_of_joining.blank? && (user.role == 'Employee' || user.role == 'HR') && user.status == 'approved'
+      return true
+    end
+    return false
   end
   
   #validates_presence_of :qualification, :date_of_joining, :personal_emailid, :on => :update

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -103,4 +103,12 @@ class User
     website_sequence_number_changed? || visible_on_website_changed?
   end
 
+  def generate_errors_message
+    error_msg = []
+    error_msg.push(errors.full_messages,
+                   public_profile.errors.full_messages,
+                   private_profile.errors.full_messages)
+    error_msg.join(' ')
+  end
+
 end

--- a/config/initializers/global_constants.rb
+++ b/config/initializers/global_constants.rb
@@ -11,3 +11,5 @@ REJECTED = 'Rejected'
 
 ORGANIZATION_DOMAIN = 'joshsoftware.com'
 ORGANIZATION_NAME = 'Josh Software'
+
+ROLE = { employee: 'Employee', HR: 'HR' }

--- a/spec/models/private_profile_spec.rb
+++ b/spec/models/private_profile_spec.rb
@@ -14,5 +14,24 @@ describe PrivateProfile do
   it { should validate_presence_of(:date_of_joining).on(:update) }
   it { should validate_presence_of(:personal_email).on(:update) }
 =end
+
+  context 'Validate Date of joining' do
+    it 'should not update user beacuse joining date is not present' do
+      user = FactoryGirl.create(:user)
+      user.status = 'approved'
+      private_profile = user.private_profile
+      private_profile.date_of_joining = ''
+
+      expect(user.save).to eq(false)
+      expect(user.generate_errors_message).to eq("Private profile is invalid  Date of joining can't be blank")
+    end
+
+    it 'should update user because joing date is present' do
+      user = FactoryGirl.create(:user)
+
+      expect(user.save).to eq(true)
+      expect(user.generate_errors_message).to eq('  ')
+    end
+  end
 end
   

--- a/spec/models/private_profile_spec.rb
+++ b/spec/models/private_profile_spec.rb
@@ -26,6 +26,32 @@ describe PrivateProfile do
       expect(user.generate_errors_message).to eq("Private profile is invalid  Date of joining can't be blank")
     end
 
+    context 'validation' do
+      let!(:user){ FactoryGirl.create(:user) }
+
+      after do
+        expect(user.save).to eq(true)
+        expect(user.valid?).to eq(true)
+      end
+
+      it 'validation should not trigger because role is not employee' do
+        user.role = 'Intern'
+        byebug
+        expect(user.role).to_not be('Employee')
+      end
+
+      it 'validayion should not trigger because role is not HR' do
+        user.role = 'Intern'
+        expect(user.role).to_not be('HR')
+      end
+    end
+
+    it 'Validation should not trigger on create' do
+      user = FactoryGirl.create(:user)
+
+      expect(user.valid?).to eq(true)
+    end
+
     it 'should update user because joing date is present' do
       user = FactoryGirl.create(:user)
 

--- a/spec/models/private_profile_spec.rb
+++ b/spec/models/private_profile_spec.rb
@@ -15,49 +15,73 @@ describe PrivateProfile do
   it { should validate_presence_of(:personal_email).on(:update) }
 =end
 
-  context 'Validate Date of joining' do
-    it 'should not update user beacuse joining date is not present' do
-      user = FactoryGirl.create(:user)
+  context 'Validate date of joining' do
+    let!(:user) { FactoryGirl.create(:user) }
+
+    before do
       user.status = 'approved'
       private_profile = user.private_profile
       private_profile.date_of_joining = ''
+    end
 
+    after do
       expect(user.save).to eq(false)
       expect(user.generate_errors_message).to eq("Private profile is invalid  Date of joining can't be blank")
     end
 
-    context 'validation' do
-      let!(:user){ FactoryGirl.create(:user) }
-
-      after do
-        expect(user.save).to eq(true)
-        expect(user.valid?).to eq(true)
-      end
-
-      it 'validation should not trigger because role is not employee' do
-        user.role = 'Intern'
-        byebug
-        expect(user.role).to_not be('Employee')
-      end
-
-      it 'validayion should not trigger because role is not HR' do
-        user.role = 'Intern'
-        expect(user.role).to_not be('HR')
-      end
+    it 'should not update user because joining date is not present, role is employee' do
+      user.role = 'Employee'
     end
 
-    it 'Validation should not trigger on create' do
-      user = FactoryGirl.create(:user)
+    it 'should not update user because joining date is not present, role is HR' do
+      user.role = 'HR'
+    end
+  end
 
+  context 'validation should not trigger' do
+    let!(:user){ FactoryGirl.create(:user) }
+
+    before do
+      user.role = 'Intern'
+      user.private_profile.date_of_joining = ''
+    end
+
+    after do
+      expect(user.save).to eq(true)
       expect(user.valid?).to eq(true)
     end
 
-    it 'should update user because joing date is present' do
-      user = FactoryGirl.create(:user)
+    it 'is not employee' do
+      expect(user.role).to_not be('Employee')
+    end
 
+    it 'is not HR' do
+      expect(user.role).to_not be('HR')
+    end
+  end
+
+  it 'Validation should not trigger on create' do
+    user = FactoryGirl.create(:user)
+
+    expect(user.valid?).to eq(true)
+  end
+
+  context 'Update user' do
+    let!(:user){ FactoryGirl.create(:user) }
+
+    after do
       expect(user.save).to eq(true)
       expect(user.generate_errors_message).to eq('  ')
     end
+
+    it 'should update user because joing date is present, role is employee' do
+      user.role = 'Employee'
+    end
+
+    it 'should update user because joing date is present, role is HR' do
+      user.role = 'HR'
+    end
   end
+
 end
   


### PR DESCRIPTION
Made joining date mandatory while approving use, if user role is Employee or HR. Because leave date is calculated based on joining date.

- Added validation for joining date field.
- Wrote test cases for same.