### PR TITLE
Update project profile

### DIFF
--- a/app/assets/stylesheets/users.css.scss
+++ b/app/assets/stylesheets/users.css.scss
@@ -68,6 +68,16 @@
   box-shadow: 2px 2px 23px 0px;
   border-radius: 10px;*/
 }
+
+.managers{
+  position: absolute;
+  max-width: 20%;
+  min-width: 20%;
+  max-height: 68%;
+  overflow-y: auto;
+  top: 43%;
+  left: 28%;
+}
 .active-projects{
   position: absolute;  
   max-width: 30%; 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -55,12 +55,12 @@ class ProjectsController < ApplicationController
   end
 
   def remove_team_member
-    unless params[:role] == 'Manager'
-      team_member = @project.users.find(params[:user_id])
-      @project.user_ids.delete(team_member.id)
-    else
+    if params[:role] == 'Manager'
       team_member = @project.managers.find(params[:user_id])
       @project.manager_ids.delete(team_member.id)
+    else
+      team_member = @project.users.find(params[:user_id])
+      @project.user_ids.delete(team_member.id)
     end
     @project.save
     @users = @project.reload.users
@@ -82,7 +82,7 @@ class ProjectsController < ApplicationController
 
   private
   def safe_params
-    params.require(:project).permit(:name, :display_name, :start_date, :end_date, :manager_ids, :code_climate_id, :code_climate_snippet,
+    params.require(:project).permit(:name, :display_name, :start_date, :end_date, :code_climate_id, :code_climate_snippet,
     :code_climate_coverage_snippet, :is_active, :is_free, :ruby_version, :rails_version, :database, :database_version, :deployment_server,
     :deployment_script, :web_server, :app_server, :payment_gateway, :image_store, :index_server, :background_jobs, :sms_gateway,
     :other_frameworks,:other_details, :image, :url, :description, :case_study,:logo, :visible_on_website, :website_sequence_number,

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -8,6 +8,7 @@ class ProjectsController < ApplicationController
   include RestfulAction
 
   def index
+    @manager_name = ''
     @projects = Project.sort_by_position
     @projects.init_list!
     respond_to do |format|
@@ -38,6 +39,7 @@ class ProjectsController < ApplicationController
 
   def show
     @users = @project.users
+    @managers = @project.managers
   end
 
   def destroy
@@ -55,8 +57,13 @@ class ProjectsController < ApplicationController
   end
 
   def remove_team_member
-    team_member = @project.users.find(params[:user_id])
-    @project.user_ids.delete(team_member.id)
+    unless params[:role] == 'Manager'
+      team_member = @project.users.find(params[:user_id])
+      @project.user_ids.delete(team_member.id)
+    else
+      team_member = @project.managers.find(params[:user_id])
+      @project.manager_ids.delete(team_member.id)
+    end
     @project.save
     @users = @project.reload.users
   end
@@ -77,12 +84,12 @@ class ProjectsController < ApplicationController
 
   private
   def safe_params
-    params.require(:project).permit(:name, :display_name, :start_date, :end_date, :managed_by, :code_climate_id, :code_climate_snippet,
+    params.require(:project).permit(:name, :display_name, :start_date, :end_date, :manager_ids, :code_climate_id, :code_climate_snippet,
     :code_climate_coverage_snippet, :is_active, :ruby_version, :rails_version, :database, :database_version, :deployment_server,
     :deployment_script, :web_server, :app_server, :payment_gateway, :image_store, :index_server, :background_jobs, :sms_gateway,
     :other_frameworks,:other_details, :image, :url, :description, :case_study,:logo, :visible_on_website, :website_sequence_number,
     :code, :number_of_employees, :invoice_date, :company_id,
-    :user_ids => [])
+    :user_ids => [], :manager_ids => [])
   end
 
   def load_project

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -1,5 +1,4 @@
 class ProjectsController < ApplicationController
-
   load_and_authorize_resource
   skip_load_and_authorize_resource :only => :create
   before_action :authenticate_user!
@@ -8,7 +7,6 @@ class ProjectsController < ApplicationController
   include RestfulAction
 
   def index
-    @manager_name = ''
     @projects = Project.sort_by_position
     @projects.init_list!
     respond_to do |format|
@@ -85,7 +83,7 @@ class ProjectsController < ApplicationController
   private
   def safe_params
     params.require(:project).permit(:name, :display_name, :start_date, :end_date, :manager_ids, :code_climate_id, :code_climate_snippet,
-    :code_climate_coverage_snippet, :is_active, :ruby_version, :rails_version, :database, :database_version, :deployment_server,
+    :code_climate_coverage_snippet, :is_active, :is_free, :ruby_version, :rails_version, :database, :database_version, :deployment_server,
     :deployment_script, :web_server, :app_server, :payment_gateway, :image_store, :index_server, :background_jobs, :sms_gateway,
     :other_frameworks,:other_details, :image, :url, :description, :case_study,:logo, :visible_on_website, :website_sequence_number,
     :code, :number_of_employees, :invoice_date, :company_id,

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -2,7 +2,12 @@ class SlackController < ApplicationController
   skip_before_filter :verify_authenticity_token
   before_action :user_exists?, only: :projects
   def projects
-    projects = @user.projects.pluck(:display_name) unless @user.nil?
+    projects =
+      unless @user.role == 'Manager'
+        @user.projects.pluck(:display_name) unless @user.nil?
+      else
+        @user.managed_projects.pluck(:name) unless @user.nil?
+      end
     projects = @slack_bot.prepend_index(projects) unless projects.blank?
     render json: { text: 'You are not working on any project' } and return if projects.blank?
     render json: { text: projects }, status: 200

--- a/app/controllers/slack_controller.rb
+++ b/app/controllers/slack_controller.rb
@@ -3,10 +3,10 @@ class SlackController < ApplicationController
   before_action :user_exists?, only: :projects
   def projects
     projects =
-      unless @user.role == 'Manager'
-        @user.projects.pluck(:display_name) unless @user.nil?
-      else
+      if @user.role == 'Manager'
         @user.managed_projects.pluck(:name) unless @user.nil?
+      else
+        @user.projects.pluck(:display_name) unless @user.nil?
       end
     projects = @slack_bot.prepend_index(projects) unless projects.blank?
     render json: { text: 'You are not working on any project' } and return if projects.blank?

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -22,6 +22,7 @@ class UsersController < ApplicationController
 
   def show
     @projects = @user.projects
+    @managed_projects = @user.managed_projects
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,8 +21,8 @@ class UsersController < ApplicationController
   end
 
   def show
-    @projects = @user.projects
-    @managed_projects = @user.managed_projects
+    @projects = @user.projects.where(is_active: 'true')
+    @managed_projects = @user.managed_projects.where(:_id.nin => @projects.pluck(:id), is_active: 'true')
   end
 
   def update

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -114,14 +114,14 @@ class Project
       all.each do |project|
         project[:is_free] = project[:is_free] == false ? 'No' : 'Yes'
         project[:allocated_employees] = project.users.count
-        project[:manager_name] = get_manager_names(project)
-        project[:employee_names] = get_employee_names(project)
+        project[:manager_name] = manager_names(project)
+        project[:employee_names] = employee_names(project)
         csv << project.attributes.values_at(*column_names)
       end
     end
   end
 
-  def self.get_manager_names(project)
+  def self.manager_names(project)
     manager_names = []
     project.managers.each do |manager|
       manager_names << manager.name
@@ -129,7 +129,7 @@ class Project
     manager_names.join(' | ')
   end
 
-  def self.get_employee_names(project)
+  def self.employee_names(project)
     employee_names = []
     project.users.each do |user|
       employee_names << user.name

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -15,7 +15,6 @@ class Project
   field :is_active, type: Boolean, default: true
   field :start_date, type: Date
   field :end_date, type: Date
-  field :managed_by
   field :image
   field :description
   field :url
@@ -50,10 +49,10 @@ class Project
   slug :name
 
   has_many :time_sheets
-  has_and_belongs_to_many :users
+  has_and_belongs_to_many :users, inverse_of: :projects
   accepts_nested_attributes_for :users
   belongs_to :company
-
+  has_and_belongs_to_many :managers, class_name: 'User', foreign_key: 'manager_ids', inverse_of: :managed_projects
   validates_presence_of :name
   validate :project_code
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,8 +35,9 @@ class User
   has_many :leave_applications
   has_many :attachments
   has_many :time_sheets
-  has_and_belongs_to_many :projects
+  has_and_belongs_to_many :projects, inverse_of: :users
   has_and_belongs_to_many :schedules
+  has_and_belongs_to_many :managed_projects, class_name: 'Project', foreign_key: 'managed_project_ids', inverse_of: :managers
 
   after_update :delete_team_cache, if: :website_fields_changed?
 

--- a/app/views/projects/_project_form.html.haml
+++ b/app/views/projects/_project_form.html.haml
@@ -15,7 +15,10 @@
           = f.check_box :is_active, {}, 'true', 'false'
         = f.input :start_date, input_html: {class: :datepicker}, value: f.object.start_date.try(:strftime, '%d-%m-%Y')
         = f.input :end_date, input_html: {class: :datepicker}, value: f.object.end_date.try(:strftime, '%d-%m-%Y')
-        = f.input :managed_by
+        .control-group
+          = label_tag "Managed By", nil, class: 'control-label'
+          .controls
+            = select_tag :manager_ids, options_from_collection_for_select(User.where(role: 'Manager', status: STATUS[2]).to_a, :id, :name, @project.managers.collect{|user| user.id}), class: 'members', multiple: true, style: "width: 340px;", "data-placeholder"=> "You can add multiple managers", name: "project[manager_ids][]"
         = label_tag "Case Study", nil, class: 'control-label'
         = f.file_field :case_study, required: true, class: 'case_study_upload', accept: "application/pdf"
         = f.input :code_climate_id, label: "Code climate id"

--- a/app/views/projects/_project_form.html.haml
+++ b/app/views/projects/_project_form.html.haml
@@ -10,15 +10,16 @@
         = f.input :display_name, required: false
         = f.input :description, as: :text, input_html: {class: "text-description"}
         = f.input :url
-        = f.label "Is Active"
-        .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "True", "data-off-label" => "False"}
-          = f.check_box :is_active, {}, 'true', 'false'
+        %div
+          = f.label "Is Active"
+          .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "True", "data-off-label" => "False"}
+            = f.check_box :is_active, {}, 'true', 'false'
+        %div
+          = f.label "Is Free"
+          .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "True", "data-off-label" => "False"}
+            = f.check_box :is_free, {}, 'true', 'false'
         = f.input :start_date, input_html: {class: :datepicker}, value: f.object.start_date.try(:strftime, '%d-%m-%Y')
         = f.input :end_date, input_html: {class: :datepicker}, value: f.object.end_date.try(:strftime, '%d-%m-%Y')
-        .control-group
-          = label_tag "Managed By", nil, class: 'control-label'
-          .controls
-            = select_tag :manager_ids, options_from_collection_for_select(User.where(role: 'Manager', status: STATUS[2]).to_a, :id, :name, @project.managers.collect{|user| user.id}), class: 'members', multiple: true, style: "width: 340px;", "data-placeholder"=> "You can add multiple managers", name: "project[manager_ids][]"
         = label_tag "Case Study", nil, class: 'control-label'
         = f.file_field :case_study, required: true, class: 'case_study_upload', accept: "application/pdf"
         = f.input :code_climate_id, label: "Code climate id"
@@ -28,6 +29,10 @@
         .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "Yes", "data-off-label" => "No"}
           = f.check_box :visible_on_website, {}, 'true', 'false'
         = f.input :number_of_employees
+        .control-group
+          = label_tag "Managed By", nil, class: 'control-label'
+          .controls
+            = select_tag :manager_ids, options_from_collection_for_select(User.where(role: 'Manager', status: STATUS[2]).to_a, :id, :name, @project.managers.collect{|user| user.id}), class: 'members', multiple: true, style: "width: 340px;", "data-placeholder"=> "You can add multiple managers", name: "project[manager_ids][]"
         .control-group
           = label_tag "Team Members", nil, class: 'control-label'
           .controls

--- a/app/views/projects/_users.html.haml
+++ b/app/views/projects/_users.html.haml
@@ -1,22 +1,34 @@
 .form-horizontal.row
   %h3
     Users
-    .offset4{style: "float: right;"}
-      .remove_underline
-        %button.btn.btn-info.btn-lg{"data-target" => "#new-team-member", "data-toggle" => "modal", :type => "button"} Add Team members
+    -if can? :manage, Project
+      .offset4{style: "float: right;"}
+        .remove_underline
+          %button.btn.btn-info.btn-lg{"data-target" => "#new-team-member", "data-toggle" => "modal", :type => "button"} Add Team members
   %table.table.table-hover
     %thead
       %tr
         %th Profile Image
         %th Name
         %th Email
-        %th Action
+        -if can? :manage, Project
+          %th Action
     %tbody
-      - @users.each do |user|
-        %tr
-          %td= image_tag(user.public_profile.image.thumb.url, class: 'img-polaroid') if user.public_profile
-          %td= link_to user.public_profile.name, user_path(user)
-          %td= user.email
-          %td= link_to '', remove_team_member_project_path(@project, user_id: user.id), method: :delete, remote: true, "data-confirm" => "Are you sure?", class: "icon-trash"
+      - if @managers.present?
+        -@managers.each do |manager|
+          %tr
+            %td= image_tag(manager.public_profile.image.thumb.url, class: 'img-polaroid') if manager.public_profile
+            %td= link_to manager.public_profile.name, user_path(manager)
+            %td= manager.email
+            -if can? :manage, Project
+              %td= link_to '', remove_team_member_project_path(@project, user_id: manager.id, role: manager.role), method: :delete, remote: true, "data-confirm" => "Are you sure?", class: "icon-trash"
+      -if @users.present?
+        - @users.each do |user|
+          %tr
+            %td= image_tag(user.public_profile.image.thumb.url, class: 'img-polaroid') if user.public_profile
+            %td= link_to user.public_profile.name, user_path(user)
+            %td= user.email
+            -if can? :manage, Project
+              %td= link_to '', remove_team_member_project_path(@project, user_id: user.id, role: user.role  ), method: :delete, remote: true, "data-confirm" => "Are you sure?", class: "icon-trash"
 
 = render 'team_member_form'

--- a/app/views/projects/_users.html.haml
+++ b/app/views/projects/_users.html.haml
@@ -16,7 +16,7 @@
     %tbody
       - if @managers.present?
         -@managers.each do |manager|
-          %tr
+          %tr{style: "background-color: lightgreen;"}
             %td= image_tag(manager.public_profile.image.thumb.url, class: 'img-polaroid') if manager.public_profile
             %td= link_to manager.public_profile.name, user_path(manager)
             %td= manager.email

--- a/app/views/projects/_users.html.haml
+++ b/app/views/projects/_users.html.haml
@@ -16,7 +16,7 @@
     %tbody
       - if @managers.present?
         -@managers.each do |manager|
-          %tr{style: "background-color: lightgreen;"}
+          %tr{style: "background-color: #DDFC90;"}
             %td= image_tag(manager.public_profile.image.thumb.url, class: 'img-polaroid') if manager.public_profile
             %td= link_to manager.public_profile.name, user_path(manager)
             %td= manager.email

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -15,15 +15,17 @@
         %th Active
         %th Allocated Employees
         %th No of Employees
+        %th Is Free
     %tbody
       - @projects.each_with_index do |p, i|
         %tr.item{"data-item-id" => p.id}
           %td= i+1
           %td=link_to p.name, project_path(p)
           - if p.managers.present?
+            - manager_name = ''
             - p.managers.each do |manager|
-              - @manager_name += manager.name + ' '
-              %td= @manager_name
+              - manager_name += manager.name + ' '
+            %td= manager_name
           - else
             %td= "NA"
           %td
@@ -35,6 +37,10 @@
               = p.is_active
           %td= p.users.count
           %td= p.number_of_employees
+          - if p.is_free == false
+            %td= 'No'
+          -else
+            %td= 'Yes'
           %td
             - if can? :manage, Project
               =link_to '', edit_project_path(p), class: "icon-edit", data: {'no-turbolink' =>  true}

--- a/app/views/projects/index.html.haml
+++ b/app/views/projects/index.html.haml
@@ -10,13 +10,22 @@
       %tr
         %th #
         %th Project Name
+        %th Manager Name
         %th Project Benchmark
         %th Active
+        %th Allocated Employees
+        %th No of Employees
     %tbody
       - @projects.each_with_index do |p, i|
         %tr.item{"data-item-id" => p.id}
           %td= i+1
           %td=link_to p.name, project_path(p)
+          - if p.managers.present?
+            - p.managers.each do |manager|
+              - @manager_name += manager.name + ' '
+              %td= @manager_name
+          - else
+            %td= "NA"
           %td
             =raw p.code_climate_snippet
             =raw p.code_climate_coverage_snippet
@@ -24,6 +33,8 @@
             - status_class = p.is_active ? 'label-success' : 'label-warning'
             .label{class: status_class}
               = p.is_active
+          %td= p.users.count
+          %td= p.number_of_employees
           %td
             - if can? :manage, Project
               =link_to '', edit_project_path(p), class: "icon-edit", data: {'no-turbolink' =>  true}

--- a/app/views/projects/show.html.haml
+++ b/app/views/projects/show.html.haml
@@ -3,47 +3,47 @@
     = @project.name
     .offset4{style: "float: right;"}
       = render partial: "layouts/project_menu"
+  - if can? :manage, Project
+    %div
+      %table.table.table-hover.table-striped
+        %tr
+          %th Project Name
+          %td= @project.name
+        %tr
+          %th Start Date
+          %td= @project.start_date
+        %tr
+          %th End Date
+          %td= @project.end_date
+        %tr
+          %th End Date
+          %td= @project.end_date
+        %tr
+          %th Invoice Date
+          %td= @project.invoice_date
+        %tr
+          %th URL
+          %td= link_to @project.url
+        %tr
+          %th Project Code
+          %td= @project.code
+        %tr
+          %th Project Description
+          %td= @project.description
+        %tr
+          %th Code climate snippet
+          %td=raw @project.code_climate_snippet
+        %tr
+          %th Comapny
+          %td= link_to @project.company.try(:name), @project.company
+        %tr
+          %th Number of Employees
+          %td= @project.number_of_employees
+  %table.table.table-hover.table-stripe
+    %tr
+      %th Logo
+      %td= image_tag @project.logo.try(:url, :thumb)
 
-  %div
-    %table.table.table-hover.table-striped
-      %tr
-        %th Project Name
-        %td= @project.name
-      %tr
-        %th Start Date
-        %td= @project.start_date
-      %tr
-        %th End Date
-        %td= @project.end_date
-      %tr
-        %th End Date
-        %td= @project.end_date
-      %tr
-        %th Invoice Date
-        %td= @project.invoice_date
-      %tr
-        %th URL
-        %td= link_to @project.url
-      %tr
-        %th Project Code
-        %td= @project.code
-      %tr
-        %th Project Description
-        %td= @project.description
-      %tr
-        %th Code climate snippet
-        %td=raw @project.code_climate_snippet
-      %tr
-        %th Comapny
-        %td= link_to @project.company.try(:name), @project.company
-      %tr
-        %th Number of Employees
-        %td= @project.number_of_employees
-      %tr
-        %th Logo
-        %td= image_tag @project.logo.try(:url, :thumb)
-
--if @users.present?
-  %div.team-member-list
-    = render 'users'
+%div.team-member-list
+  = render 'users'
 

--- a/app/views/users/_managed_project.html.haml
+++ b/app/views/users/_managed_project.html.haml
@@ -1,0 +1,14 @@
+%tr
+  %td.project-name
+    - if user_signed_in?
+      = link_to managed_project.name, project_path(id: managed_project.id)
+    - else
+      = managed_project.name
+  %td= raw managed_project.code_climate_snippet
+  %td= raw managed_project.code_climate_coverage_snippet
+
+:css
+  .table{ margin-top: 30px; }
+  .table th { border-top: 1px solid #ffffff; }
+  .table td { border-top: 1px solid #ffffff; padding: 4px;}
+  .project-name{font-weight: bold;}

--- a/app/views/users/_managed_project.html.haml
+++ b/app/views/users/_managed_project.html.haml
@@ -8,7 +8,7 @@
   %td= raw managed_project.code_climate_coverage_snippet
 
 :css
-  .table{ margin-top: 30px; }
+  /*.table{ margin-top: 30px; }*/
   .table th { border-top: 1px solid #ffffff; }
   .table td { border-top: 1px solid #ffffff; padding: 4px;}
   .project-name{font-weight: bold;}

--- a/app/views/users/_project.html.haml
+++ b/app/views/users/_project.html.haml
@@ -8,7 +8,7 @@
   %td= raw project.code_climate_coverage_snippet
 
 :css
-  .table{ margin-top: 30px; }
+  /* .table{ margin-top: 30px; } */
   .table th { border-top: 1px solid #ffffff; }
   .table td { border-top: 1px solid #ffffff; padding: 4px;}
   .project-name{font-weight: bold;}

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,11 +1,11 @@
 = render 'profile'
 - unless @projects.empty?
   .projects
-    %table.table
+    %table
       = render partial: 'project', collection: @projects
 - unless @managed_projects.empty?
-  .projects
-    %table.table
+  .managers
+    %table
       = render partial: 'managed_project', collection: @managed_projects
 - unless @user.role.eql?('Admin')
   .bonusly-updates.common-bonusly-updates

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -3,6 +3,10 @@
   .projects
     %table.table
       = render partial: 'project', collection: @projects
+- unless @managed_projects.empty?
+  .projects
+    %table.table
+      = render partial: 'managed_project', collection: @managed_projects
 - unless @user.role.eql?('Admin')
   .bonusly-updates.common-bonusly-updates
     %ul.nav.nav-tabs

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -43,6 +43,19 @@ describe ProjectsController do
     end
   end
 
+  describe 'PATCH update' do
+    let!(:user) { FactoryGirl.create(:user) }
+    let!(:project) { FactoryGirl.create(:project) }
+
+    it 'Should update manager ids and managed_project_ids' do
+      user_id = []
+      user_id << user.id
+      patch :update, id: project.id, project: { manager_ids: user_id }
+      expect(project.reload.manager_ids.include?(user.id)).to eq(true)
+      expect(user.reload.managed_project_ids.include?(project.id)).to eq(true)
+    end
+  end
+
   describe "GET show" do
     it "should find one project record" do
       project = FactoryGirl.create(:project)
@@ -92,6 +105,7 @@ describe ProjectsController do
       user.save
       delete :remove_team_member, :format => :js, id: project.id, user_id: user.id, role: user.role
       expect(project.reload.manager_ids.include?(user.id)).to eq(false)
+      expect(user.reload.managed_project_ids.include?(user.id)).to eq(false)
     end
 
     it 'Should delete employee' do
@@ -101,6 +115,7 @@ describe ProjectsController do
       user.save
       delete :remove_team_member, :format => :js, id: project.id, user_id: user.id, role: user.role
       expect(project.reload.user_ids.include?(user.id)).to eq(false)
+      expect(user.reload.managed_project_ids.include?(user.id)).to eq(false)
     end
   end
 end

--- a/spec/controllers/projects_controller_spec.rb
+++ b/spec/controllers/projects_controller_spec.rb
@@ -49,6 +49,14 @@ describe ProjectsController do
       get :show, id: project.id
       expect(assigns(:project)).to eq(project)
     end
+
+    it 'Should equal to managers' do
+      user = FactoryGirl.create(:user, role: 'Manager')
+      project = FactoryGirl.create(:project)
+      project.managers << user
+      get :show, id: project.id
+      expect(assigns(:managers)).to eq(project.managers)
+    end
   end
 
   describe "GET generate_code" do
@@ -72,6 +80,27 @@ describe ProjectsController do
       expect(last.position).to eq(3)
       xhr :post, :update_sequence_number, id:  projects.last.id, position: 1
       expect(last.reload.position).to eq(1)
+    end
+  end
+
+  describe 'DELETE team member' do
+    let!(:project) { FactoryGirl.build(:project) }
+    it 'Should delete manager' do
+      user = FactoryGirl.build(:user, role: 'Manager')
+      project.managers << user
+      project.save
+      user.save
+      delete :remove_team_member, :format => :js, id: project.id, user_id: user.id, role: user.role
+      expect(project.reload.manager_ids.include?(user.id)).to eq(false)
+    end
+
+    it 'Should delete employee' do
+      user = FactoryGirl.build(:user, role: 'Employee')
+      project.users << user
+      project.save
+      user.save
+      delete :remove_team_member, :format => :js, id: project.id, user_id: user.id, role: user.role
+      expect(project.reload.user_ids.include?(user.id)).to eq(false)
     end
   end
 end

--- a/spec/controllers/slack_controller_spec.rb
+++ b/spec/controllers/slack_controller_spec.rb
@@ -25,6 +25,17 @@ RSpec.describe SlackController do
       expect(resp['text']).to eq("1. tpn\n2. Dealsignal")
     end
 
+    it 'Should give the managed projects name' do
+      user = FactoryGirl.create(:user, role: 'Manager')
+      params = { user_id: USER_ID, channel_id: CHANNEL_ID }
+      project_tpn.managers << user
+      project_ds.managers << user
+      post :projects, params
+      resp = JSON.parse(response.body)
+      expect(response).to have_http_status(200)
+      expect(resp['text']).to eq("1. tpn\n2. Dealsignal")
+    end
+
     it 'Should give message : You are not working on any project' do
       user.projects.destroy_all
       params = { user_id: USER_ID, channel_id: CHANNEL_ID }

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -57,4 +57,23 @@ describe Project do
     end
   end
 
+  context 'manager name and employee name' do
+    let!(:user) { FactoryGirl.create(:user) }
+
+    it 'Should match manager name' do
+      manager = FactoryGirl.create(:user)
+      project = FactoryGirl.create(:project)
+      project.managers << user
+      project.managers << manager
+
+      manager_names = Project.get_manager_names(project)
+      expect(manager_names).to eq("fname lname | fname lname")
+    end
+
+    it 'Should match employee name' do
+      project = user.projects.create(name: 'test1')
+      employee_names = Project.get_employee_names(project)
+      expect(employee_names).to eq("fname lname")
+    end
+  end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -66,13 +66,13 @@ describe Project do
       project.managers << user
       project.managers << manager
 
-      manager_names = Project.get_manager_names(project)
+      manager_names = Project.manager_names(project)
       expect(manager_names).to eq("fname lname | fname lname")
     end
 
     it 'Should match employee name' do
       project = user.projects.create(name: 'test1')
-      employee_names = Project.get_employee_names(project)
+      employee_names = Project.employee_names(project)
       expect(employee_names).to eq("fname lname")
     end
   end


### PR DESCRIPTION
- On project edit form show drop down with all manger names.
- On project information form show the mangers also and show the project information to admin and manager only.
- On project profile add the field manager name, number of allocated employee, number of employee. Download the project list all these field and add employee list in downloaded CSV.
- When manager fire /projects command show all the project on which they are assign.
- Add one checkbox in project listing as "is free" and default value false.