### PR TITLE
Employee Auto Id generation 

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -43,7 +43,7 @@ class User
 
   after_update :delete_team_cache, if: :website_fields_changed?
   before_create :associate_employee_id
-  after_update :associate_employee_if_role_changed
+  after_update :associate_employee_id_if_role_changed
 
 
   accepts_nested_attributes_for :attachments, reject_if: :all_blank, :allow_destroy => true
@@ -184,11 +184,10 @@ class User
     return if self.role.eql?(INTERN_ROLE)
     employee_id_array = User.distinct("employee_detail.employee_id")
     emp_id = employee_id_array.empty? ?  0 : employee_id_array.map{|id| id.to_i}.max + 1
-    byebug
     self.employee_detail.present? ?  self.employee_detail.update_attributes(employee_id: emp_id) : EmployeeDetail.new(employee_id: emp_id)
   end
 
-  def associate_employee_if_role_changed
+  def associate_employee_id_if_role_changed
     if role_changed?
       if role_was ==  INTERN_ROLE && self.employee_detail.employee_id.nil?
         associate_employee_id

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,8 +183,9 @@ class User
   def associate_employee_id
     return if self.role.eql?(INTERN_ROLE)
     employee_id_array = User.distinct("employee_detail.employee_id")
-    emp_id = employee_id_array.empty? ?  0 : employee_id_array.map{|id| id.to_i}.max 
-    self.employee_detail.present? ?  self.employee_detail.update_attributes(employee_id: emp_id + 1) : EmployeeDetail.new(employee_id: emp_id + 1)
+    emp_id = employee_id_array.empty? ?  0 : employee_id_array.map{|id| id.to_i}.max
+    emp_id = emp_id + 1
+    self.employee_detail.present? ?  self.employee_detail.update_attributes(employee_id: emp_id) : self.employee_detail = EmployeeDetail.new(employee_id: emp_id)
   end
 
   def associate_employee_id_if_role_changed

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,8 +183,8 @@ class User
   def associate_employee_id
     return if self.role.eql?(INTERN_ROLE)
     employee_id_array = User.distinct("employee_detail.employee_id")
-    emp_id = employee_id_array.empty? ?  0 : employee_id_array.map{|id| id.to_i}.max + 1
-    self.employee_detail.present? ?  self.employee_detail.update_attributes(employee_id: emp_id) : EmployeeDetail.new(employee_id: emp_id)
+    emp_id = employee_id_array.empty? ?  0 : employee_id_array.map{|id| id.to_i}.max 
+    self.employee_detail.present? ?  self.employee_detail.update_attributes(employee_id: emp_id + 1) : EmployeeDetail.new(employee_id: emp_id + 1)
   end
 
   def associate_employee_id_if_role_changed

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -305,7 +305,7 @@ describe User do
 
     it "should not generate ID if employee is exist" do
       user = FactoryGirl.create(:user, public_profile: FactoryGirl.build(:public_profile))
-      expect(user.new_employee_id.employee_id).to eq(user.employee_detail.employee_id)
+      expect(user.employee_detail.employee_id).to eq(user.employee_detail.employee_id)
     end
 
     it "should not generate ID if user role is Intern" do
@@ -315,7 +315,7 @@ describe User do
 
     it "should generate id when user role is changed Intern to Employee" do
       internuser.update_attributes(role: "Employee")
-      expect(internuser.employee_detail.employee_id.to_i).to eq(1)
+      expect(internuser.employee_detail.employee_id.to_i).to eq(2)
     end
 
     it "should not override other details when user role is changed intern to employee" do
@@ -326,7 +326,9 @@ describe User do
       expect(internuser.doj_month).to eq(internuser.doj_month)
       expect(internuser.email).to eq(internuser.email)
       expect(internuser.status).to eq(internuser.status)
-      expect(internuser.employee_detail.employee_id.to_i).to eq(1)
+      expect(internuser.employee_detail.employee_id.to_i).to eq(2)
+      expect(internuser.employee_detail.date_of_relieving).to eq(internuser.employee_detail.date_of_relieving)
+      expect(internuser.employee_detail.available_leaves).to eq(internuser.employee_detail.available_leaves)
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -295,4 +295,26 @@ describe User do
       end
     end
   end
+  context 'Employee Auto Id generation' do
+    let!(:user) { FactoryGirl.create(:user,public_profile: FactoryGirl.build(:public_profile)) }
+    it "should generate new Employee ID if employee is new" do      
+      user = FactoryGirl.create(:user, public_profile: FactoryGirl.build(:public_profile))
+      expect(user.employee_detail.employee_id.to_i).to eq(2)
+    end
+
+    it "should not generate ID if employee is exist" do
+      user = FactoryGirl.create(:user, public_profile: FactoryGirl.build(:public_profile))
+      expect(user.new_employee_id.employee_id).to eq(user.employee_detail.employee_id)
+    end
+
+    it "should not generate ID if user role is Intern" do
+      user = FactoryGirl.create(:user, role: 'Intern', email: 'intern@company.com')
+      expect(user.employee_detail).to eq(nil)
+    end
+
+    it "should generate id when user role is changed Intern to Employee" do
+      user.update_attributes(role: "Employee")
+      expect(user.employee_detail.employee_id.to_i).to eq(1)
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -297,6 +297,7 @@ describe User do
   end
   context 'Employee Auto Id generation' do
     let!(:user) { FactoryGirl.create(:user,public_profile: FactoryGirl.build(:public_profile)) }
+    let(:internuser) { FactoryGirl.create(:user, role: 'Intern', email: 'intern@joshsoftware.com',employee_detail: FactoryGirl.build(:employee_detail))}
     it "should generate new Employee ID if employee is new" do      
       user = FactoryGirl.create(:user, public_profile: FactoryGirl.build(:public_profile))
       expect(user.employee_detail.employee_id.to_i).to eq(2)
@@ -308,13 +309,24 @@ describe User do
     end
 
     it "should not generate ID if user role is Intern" do
-      user = FactoryGirl.create(:user, role: 'Intern', email: 'intern@company.com')
+      user = FactoryGirl.create(:user, role: 'Intern', email: 'intern@joshsoftware.com')
       expect(user.employee_detail).to eq(nil)
     end
 
     it "should generate id when user role is changed Intern to Employee" do
-      user.update_attributes(role: "Employee")
-      expect(user.employee_detail.employee_id.to_i).to eq(1)
+      internuser.update_attributes(role: "Employee")
+      expect(internuser.employee_detail.employee_id.to_i).to eq(1)
+    end
+
+    it "should not override other details when user role is changed intern to employee" do
+      internuser.update_attributes(role: "Employee")
+      expect(internuser.dob_day).to eq(internuser.dob_day)
+      expect(internuser.dob_month).to eq(internuser.dob_month)
+      expect(internuser.doj_day).to eq(internuser.doj_day)
+      expect(internuser.doj_month).to eq(internuser.doj_month)
+      expect(internuser.email).to eq(internuser.email)
+      expect(internuser.status).to eq(internuser.status)
+      expect(internuser.employee_detail.employee_id.to_i).to eq(1)
     end
   end
 end


### PR DESCRIPTION
1. whenever new user will created except intern then it should have to generate Employee Id
2. When user role is changed Intern to Employee then Employee Id should generate.