### PR TITLE
Timesheet update features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,4 @@
 /log/*
 /doc/
 /public/newsletter/
+.byebug_history

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -19,9 +19,7 @@ class TimeSheet
   validates :date, presence: true, if: :is_future_date?
   validates :from_time, presence: true, if: :from_time_is_future_time?
   validates :to_time, presence: true, if: :to_time_is_future_time?
-
   after_validation :check_vadation_while_creating_or_updateing_timesheet
-  before_validation :valid_date_for_update?, on: :update
   before_validation :valid_date_for_create?, on: :create
   validate :time_sheet_overlapping?
 
@@ -103,12 +101,7 @@ class TimeSheet
   end
 
   def valid_date_for_update?
-    if date < Date.today - DAYS_FOR_UPDATE
-      text = "Not allowed to edit timesheet for this date. You can edit timesheet for past #{DAYS_FOR_UPDATE} days."
-      errors.add(:date, text)
-      return false
-    end
-    return true
+    date > Date.today - DAYS_FOR_UPDATE
   end
 
   def valid_date_for_create?

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -91,6 +91,14 @@ class User
     return false
   end
 
+  def is_employee_or_intern?
+    [ROLE[:intern], ROLE[:employee]].include?(role)
+  end
+
+  def is_admin_or_hr?
+    [ROLE[:HR], ROLE[:admin]].include?(role)
+  end  
+
   def allow_in_listing?
     return true if self.status == 'approved'
     return false

--- a/app/views/time_sheets/index.html.haml
+++ b/app/views/time_sheets/index.html.haml
@@ -5,6 +5,8 @@
     %label To Date:
     = text_field_tag :to_date, params[:to_date], class: "form-control datepicker", placeholder: "To Date", value: @to_date, style: "height: 2em;"
     = submit_tag "Search", class: "btn btn-primary"
-
+    .pull-right
+      - if [ROLE[:intern], ROLE[:employee]].include?(current_user.role)
+        = link_to '', new_time_sheet_path(user_id: current_user.id, from_date: @from_date, to_date: @to_date), "data-toggle" => "tooltip", title: 'Add Timesheet', class: "icon-plus add-timesheet-icon"
 .timesheet_report
   = render 'time_sheets/timesheet_report_view', timesheet_reports: @timesheet_report


### PR DESCRIPTION
Current user can edit his/her timesheet for 2 days before the current date.
Change Done: Admin, HR & Manager can change the timesheet of employees without any time or date limit.