### PR TITLE
Add association designation

### DIFF
--- a/app/models/designation.rb
+++ b/app/models/designation.rb
@@ -1,0 +1,10 @@
+class Designation
+  include Mongoid::Document
+  include Mongoid::Timestamps
+
+  field :name, type: String
+
+  has_many :users
+
+  validates :name, presence: true, uniqueness: true
+end

--- a/app/models/employee_detail.rb
+++ b/app/models/employee_detail.rb
@@ -8,12 +8,10 @@ class EmployeeDetail
   field :date_of_relieving, :type => Date
   field :notification_emails, type: Array
   field :available_leaves, type: Integer, default: 0
-  field :designation, type: String
   field :description
   field :is_billable, type: Boolean, default: false
 
-  DESIGNATIONS = ["Co-Founder & Director", "Director", "Director Engineering" , "Software Architect", "Team Lead","Operations Head",
-                  "Senior QA & Developer", "Senior Software Engineer","Senior Accountant", "HR Executive", "Android Developer", "Software Engineer", "iOS Developer", "People & Culture Manager"]
+  belongs_to :designation
 
   validates :employee_id, uniqueness: true
   validates :available_leaves, numericality: {greater_than_or_equal_to: 0}

--- a/app/views/users/_employee_detail.html.haml
+++ b/app/views/users/_employee_detail.html.haml
@@ -1,7 +1,7 @@
 = simple_form_for(@user,:url => user_path(@user), :html => { method: :put, class: "form-horizontal", multipart: true}) do |f|
   = f.simple_fields_for :employee_detail do |e|
     = e.input :employee_id, label: "Employee Id", disabled: true
-    = e.input :designation, collection: EmployeeDetail::DESIGNATIONS, prompt: 'Select Designation'
+    = e.input :designation, as: :select, collection: Designation.all, prompt: 'Select Designation', selected: e.object.try(:designation_id)
     = e.input :description, as: :text, input_html: {class: 'text-description'}
     = e.input :date_of_relieving, input_html: {class: 'datepicker', 'data-behaviour' => 'datepicker', value: @user.employee_detail.date_of_relieving.try(:strftime, '%d-%m-%Y')}
     = e.input :notification_emails, collection: @emails, input_html: {class: 'notification_emails', multiple: true, style: "width:240px;", "data-placeholder" => "You can add multiple emails"}

--- a/app/views/users/index.xlsx.axlsx
+++ b/app/views/users/index.xlsx.axlsx
@@ -5,6 +5,6 @@ wb.add_worksheet(name: "Employees") do |sheet|
   counter = 0
   @usersxls.each do |user|
     counter += 1
-    sheet.add_row [counter, user.employee_id, user.name, user.email, user.role, user.designation, user.status, user.mobile_number, user.date_of_birth,  user.date_of_joining, user.date_of_relieving]
+    sheet.add_row [counter, user.employee_id, user.name, user.email, user.role, user.designation.try(:name), user.status, user.mobile_number, user.date_of_birth,  user.date_of_joining, user.date_of_relieving]
   end
 end

--- a/lib/tasks/add_association_designation.rake
+++ b/lib/tasks/add_association_designation.rake
@@ -1,0 +1,45 @@
+require 'csv'
+desc 'Add association between EmployeeDetail & Designation from csv'
+namespace :add_association_designation do
+
+  task :add_designation_to_employee_detail =>
+    [:environment, :add_default_designations] do
+    file = "#{Rails.root}/tmp/employee_data.csv"
+    CSV.open(file, 'r', headers: true).each do |reader|
+      user = User.find(reader['User ID'])
+      employee_detail = user.employee_detail
+      if reader['Designation'].blank?
+        next
+      else
+        designation = Designation.find_by(name: reader['Designation'])
+        employee_detail.designation = designation
+        employee_detail.save!
+      end
+    end
+    CSV.open(file, 'r', headers: true).each do |reader|
+      user = User.find(reader['User ID'])
+      emp_det = user.employee_detail
+      if reader['Designation'].blank?
+        next
+      else
+        desg    = Designation.find_by(name: reader['Designation'])
+        if emp_det.designation_id.blank? || (emp_det.designation != desg)
+          puts "Invalid designation assigned to user #{user.id.to_s}"
+        end
+      end
+    end
+  end
+
+  task :add_default_designations => :environment do
+    DESIGNATIONS = [
+      "Co-Founder & Director", "Director", "Director Engineering",
+      "Software Architect", "Team Lead", "Operations Head",
+      "Senior QA & Developer", "Senior Software Engineer", "Senior Accountant",
+      "HR Executive", "Android Developer", "Software Engineer", "iOS Developer",
+      "People & Culture Manager"
+    ]
+    DESIGNATIONS.each do |designation|
+      Designation.create(name: designation)
+    end
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -119,6 +119,21 @@ describe UsersController do
       patch :update, id: user.id, user: { project_ids: project_ids }
       expect(flash[:error]).to be_present
     end
+
+    it 'should update designation successfully' do
+      designations = FactoryGirl.create_list(:designation, 2)
+      employee_detail = user.employee_detail
+      employee_detail.designation = designations[0]
+      employee_detail.save
+      put :update, id: user.id, user: {
+        employee_detail_attributes: {
+          designation: designations[1],
+          id: employee_detail.id
+        }
+      }
+      expect(flash[:notice]).to be_present
+      expect(user.reload.designation).to eq(designations[1])
+    end
   end
 
   context "get_feed" do

--- a/spec/factories/designations.rb
+++ b/spec/factories/designations.rb
@@ -1,0 +1,5 @@
+FactoryGirl.define do
+  factory :designation do
+    name { Faker::Job.title }
+  end
+end

--- a/spec/models/designation_spec.rb
+++ b/spec/models/designation_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+RSpec.describe Designation do
+
+  it { should be_mongoid_document }
+
+  it { should have_field(:name) }
+
+  it { should have_many(:users) }
+
+  it { should validate_presence_of(:name) }
+  it { should validate_uniqueness_of(:name) }
+end

--- a/spec/models/employee_detail_spec.rb
+++ b/spec/models/employee_detail_spec.rb
@@ -1,5 +1,6 @@
 require 'spec_helper'
 
 describe EmployeeDetail do
-  pending "add some examples to (or delete) #{__FILE__}"
+
+  it { should belong_to(:designation) }
 end


### PR DESCRIPTION
1) Added model Designation.
2) Removed field designation from EmployeeDetail.
3) Added association between Designation & EmployeeDetail.
4) Added rake task to add default designations and associate current users with designations. Command to run the task: 'rake add_association_designation:add_designation_to_employee_detail'