### PR TITLE
added functionality to reject future leaves of resigned employees

### DIFF
--- a/lib/tasks/resigned_employees.rake
+++ b/lib/tasks/resigned_employees.rake
@@ -1,0 +1,16 @@
+namespace :resigned_employees do
+  desc "Reject all leaves of resigned employees"
+  task reject_future_leaves: :environment do
+    User.where(:status.ne => 'approved').each do |user|
+      user.reject_future_leaves
+    end
+  end
+
+  desc "Change status of resigned employees from pending to resigned"
+  task change_status_of_resigned_employees: :environment do
+    email_ids = []
+    User.where(:email.in => email_ids).each do |user|
+      user.update(status: 'resigned')
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -58,6 +58,17 @@ describe User do
     expect(user.employee_detail.available_leaves).to eq(PER_MONTH_LEAVE*12)
   end
 
+  context '#reject_future_leaves' do
+    it 'should reject future leaves if employee resigns' do
+      user = FactoryGirl.create(:user, status: 'approved')
+      leave_application1 = FactoryGirl.create(:leave_application, user: user)
+      leave_application2 = FactoryGirl.create(:leave_application, user: user, start_at: Date.today + 4, end_at: Date.today + 7)
+      user.update(status: 'resigned')
+      expect(leave_application1.reload.leave_status).to eq('Rejected')
+      expect(leave_application2.reload.leave_status).to eq('Rejected')
+    end
+  end
+
   context "sent mail for approval" do
 
     before (:each) do


### PR DESCRIPTION
added rake tasks for 
1. rejecting future leaves of all resigned employees
2. changing status of resigned employees from pending to resigned
added a hook for rejecting future leaves if employee status becomes resigned