### PR TITLE
bug fixed for edit project team details

### DIFF
--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -44,7 +44,7 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    update_obj(@project, safe_params, projects_path)
+    update_obj(@project, safe_params, edit_project_path)
   end
 
   def show

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -110,7 +110,12 @@ class ProjectsController < ApplicationController
   end
 
   def load_users
-    # @users = User.project_engineers
-    @users = User.approved.where(:role.nin => ['Admin', 'Manager'])
+    designations = ['UI/UX Lead', 'UI/UX Designer', 'Senior UI/UX Designer', 'Software Engineer', 'Senior Software Engineer', 'Team Lead', 'QA Engineer', 'Senior QA Engineer', 'QA Lead', 'Intern']
+    designation_ids = Designation.where(:name.in => designations).pluck(:id)
+    @users = User.project_engineers.select do |user|
+      if user.employee_detail.designation_id.present?
+        designation_ids.include?(user.employee_detail.designation_id)
+      end
+    end
   end
 end

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -44,7 +44,7 @@ class ProjectsController < ApplicationController
   end
 
   def update
-    if update_obj(@project, safe_params, projects_path)
+    if update_obj(@project, safe_params, edit_project_path)
       @project.add_manager_as_team_member(params[:project][:manager_ids] || [])
     else
       flash[:error] = "Error unable to add or remove team member"
@@ -115,6 +115,7 @@ class ProjectsController < ApplicationController
   end
 
   def load_users
-    @users = User.project_engineers
+    # @users = User.project_engineers
+    @users = User.approved.where(:role.nin => ['Admin', 'Manager'])
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -201,27 +201,28 @@ class Project
     end
   end
 
-  def add_or_remove_team_members(user_ids)
-    user_ids = user_ids.presence ? user_ids.collect!(&:to_s) : []
-    existing_member_ids = user_projects.where(end_date: nil).pluck(:user_id).collect(&:to_s)
-    new_member_ids = user_ids.present? ? user_ids - existing_member_ids : []
-    removed_member_ids = user_ids.present? ? existing_member_ids - user_ids : []
-    add_team_members(new_member_ids) if new_member_ids.present?
-    remove_team_members(removed_member_ids) if removed_member_ids.present?
-  end
-
-  def add_team_members(user_ids)
-    user_ids.each do |user_id|
-      user_projects.create!(user_id: user_id, start_date: DateTime.now, end_date: nil)
-    end
-  end
-
-  def remove_team_members(user_ids)
-    user_ids.each do |user_id|
-      user_project = user_projects.where(user_id: user_id, end_date: nil).first
-      user_project.update_attributes(end_date: DateTime.now, active: false) if user_project
-    end
-  end
+  # these methods were used to add managers as team members but it had a bug
+  # def add_or_remove_team_members(user_ids)
+  #   user_ids = user_ids.presence ? user_ids.collect!(&:to_s) : []
+  #   existing_member_ids = user_projects.where(end_date: nil).pluck(:user_id).collect(&:to_s)
+  #   new_member_ids = user_ids.present? ? user_ids - existing_member_ids : []
+  #   removed_member_ids = user_ids.present? ? existing_member_ids - user_ids : []
+  #   add_team_members(new_member_ids) if new_member_ids.present?
+  #   remove_team_members(removed_member_ids) if removed_member_ids.present?
+  # end
+  #
+  # def add_team_members(user_ids)
+  #   user_ids.each do |user_id|
+  #     user_projects.create!(user_id: user_id, start_date: DateTime.now, end_date: nil)
+  #   end
+  # end
+  #
+  # def remove_team_members(user_ids)
+  #   user_ids.each do |user_id|
+  #     user_project = user_projects.where(user_id: user_id, end_date: nil).first
+  #     user_project.update_attributes(end_date: DateTime.now, active: false) if user_project
+  #   end
+  # end
 
   def self.get_approved_project_between_range(from_date, to_date)
     Project.all_active.where("$or" => [{end_date: nil}, {end_date: {"$gte" => from_date, "$lte" => to_date}}]).pluck(:name, :id)

--- a/app/views/projects/_team_info_form.html.haml
+++ b/app/views/projects/_team_info_form.html.haml
@@ -13,8 +13,12 @@
       - if project_user_form.object.user.blank? || (project_user_form.object.user && project_user_form.object.user.is_approved? && (project_user_form.object.active || project_user_form.object.end_date.nil?))
         .row.span12
           .span2.width12
-            .make-switch{"data-on" => "success", "data-off" => "danger", "data-on-label" => "Yes", "data-off-label" => "No"}
-              = project_user_form.check_box :active, {class: "active-check-box"}, 'true', 'false'
+            - if project_user_form.object.user.blank?
+              .new-switch{"data-on" => "success", "data-off" => "danger", "data-on-label" => "Yes", "data-off-label" => "No"}
+                = project_user_form.check_box :active, {class: "active-check-box"}, 'true', 'false'
+            - else
+              .make-switch{"data-on" => "success", "data-off" => "danger", "data-on-label" => "Yes", "data-off-label" => "No"}
+                = project_user_form.check_box :active, {class: "active-check-box"}, 'true', 'false'
           .span2.width18
             = project_user_form.input :user_id, collection: users, input_html: {class: "user_select"}, label: false
           .span2.width15
@@ -22,10 +26,16 @@
           .span2.width15
             = project_user_form.input :end_date, input_html: {class: :datepicker, style: "height: 32px", id: "end-date"},  label: false
           .span2.width10
-            .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "REQ", "data-off-label" => "NREQ"}
-              = project_user_form.check_box :time_sheet
+            - if project_user_form.object.user.blank?
+              .new-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "REQ", "data-off-label" => "NREQ"}
+                = project_user_form.check_box :time_sheet
+            - else
+              .make-switch{"data-on" => "success", "data-off" => "warning", "data-on-label" => "REQ", "data-off-label" => "NREQ"}
+                = project_user_form.check_box :time_sheet
           .span2.width10
             = project_user_form.input :allocation, {min: 0, max: 100, step: 1, style: "height: 32px;", label: false, class: 'allotment'}
+          - if project_user_form.object.user.blank?
+            = project_user_form.link_to_remove "Cancel", class: "btn btn-danger"
   .offset3
     = f.link_to_add "Add team member", :user_projects, data: {target: '#team-members'}, class: "btn btn-success", id: "add-team-members-button"
     = f.submit :Save, class: 'btn controls btn-info'
@@ -71,12 +81,29 @@
   })
 
   $(document).ready(function(){
+    makeSwitches()
     $(".user_select").select2()
   })
 
   $(document).on('nested:fieldAdded', function(event){
-    var checkBoxes = $(".make-switch")
-    checkBoxes.bootstrapSwitch()
+    makeSwitches()
     var selectField = event.field.find(".user_select")
     selectField.select2()
   })
+
+  function makeSwitches(){
+    var checkBoxes = $(".new-switch")
+    checkBoxes.bootstrapSwitch()
+    referenceCheckBox = $(".make-switch")
+    checkBoxes.height(referenceCheckBox.height())
+    checkBoxes.css('margin-left','4px')
+  }
+
+  // link_to_remove just hides the row instead of removing it from the form
+  $(document).on('nested:fieldRemoved', function(event) {
+    $("div").each(function(index, value) {
+      if($(value).css("display") == 'none' && $(value).hasClass('fields')){
+        value.parentNode.removeChild(value);
+      }
+    });
+  });


### PR DESCRIPTION
Should solve
1. managers & admins  shouldn't be part of that form (handle it using query)
2. when I add new member, above row's toggle buttons don;t work
3. if I add a new row till is not saved, need an option to remove that row
after saved compulsarily needs to inactivate user so as to remove from project
after saved part is working for 3
4. after saving team details & tech details, needs to redirect on project edit page only instead projects listing