### PR TITLE
New API for Github Quest

### DIFF
--- a/app/controllers/api/v1/project_controller.rb
+++ b/app/controllers/api/v1/project_controller.rb
@@ -1,0 +1,20 @@
+class Api::V1::ProjectController < ApplicationController
+  
+  def index
+    render json: { projects: Project.get_all_sorted_by_name.as_json(project_info_fields) }
+  end
+
+  private
+
+  def project_info_fields
+    {
+      only: [:_id, :name],
+      include: {
+        repositories: {
+          only: [:url, :host]
+        }
+      },
+      methods: [:active_users]
+    }
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,5 +1,5 @@
 class Api::V1::UsersController < ApplicationController
-  before_action :authenticate_user!
+  before_action :authenticate_user!, only: [:info]
   skip_before_filter :verify_authenticity_token
 
   def info
@@ -7,6 +7,25 @@ class Api::V1::UsersController < ApplicationController
     render json: { id: current_user.id.to_s,
       email: current_user.email,
       name: current_user.name
+    }
+  end
+
+  def index
+    render json: { users: User.employees.as_json(user_info_fields) }
+  end
+
+  private
+
+  def user_info_fields
+    {
+      only: [:_id, :name, :email, :role],
+      methods: [:name],
+      include: {
+        public_profile: {
+          only: [
+            :github_handle, :gitlab_handle, :bitbucket_handle]
+        }
+      }
     }
   end
 end

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -18,4 +18,55 @@ class Repository
   field :rollbar_access_token
   has_many :rollbar_statistics, dependent: :destroy
   validates_uniqueness_of :code_climate_id, allow_blank: true, allow_nil: true
+
+  after_create do
+    call_monitor_service('created')
+  end
+
+  before_destroy do
+    call_monitor_service('destroyed')
+  end
+
+  # before_save do
+  #   # for change in url, name, host
+  #   if persisted? and (changes.keys & ['url', 'name', 'host']).length > 0
+  #     call_monitor_service('updated')
+  #   end
+  # end
+
+  private
+
+  def call_monitor_service(event)
+    CodeMonitoringWorker.perform_async(monitor_service_params(event))
+  end
+
+  def monitor_service_params(event)
+    data = {
+      event_type:         '',
+      repository_id:      id.to_s,
+      repository_url:     url,
+      project_id:         project_id.to_s,
+      repository_details: self.as_json(repository_fields)
+    }
+    case event
+    when 'created'
+      data[:event_type] = 'Repository Added'
+    when 'destroyed'
+      data[:event_type] = 'Repository Removed'
+      data[:project_id] = project_id_was.to_s
+      data.delete(:repository_details)
+    # when 'updated'
+    #   data[:event_type] = 'Repository Update'
+    end
+    data
+  end
+
+  def repository_fields
+    {
+      only: [
+        :name, :host, :code_climate_id, :maintainability_badge,
+        :test_coverage_badge, :visibility, :rollbar_access_token
+      ]
+    }
+  end
 end

--- a/app/models/user_project.rb
+++ b/app/models/user_project.rb
@@ -20,6 +20,7 @@ class UserProject
       message: 'not less than 0 & not more than 160'
   }
 
+  after_save :call_monitor_service, if: 'active_changed?'
 
   validates :end_date, presence: {unless: "!!active || active.nil?", message: "is mandatory to mark inactive"}
   validate :start_date_less_than_end_date, if: 'end_date.present?'
@@ -32,6 +33,26 @@ class UserProject
   def start_date_less_than_end_date
     if end_date < start_date
       errors.add(:end_date, 'should not be less than start date.')
+    end
+  end
+
+  def call_monitor_service
+    CodeMonitoringWorker.perform_async(monitor_service_params)
+  end
+
+  def monitor_service_params
+    if active
+      {
+        event_type: 'User Added',
+        user_id: user_id.to_s,
+        project_id: project_id.to_s
+      }
+    else
+      {
+        event_type: 'User Removed',
+        user_id: user_id.to_s,
+        project_id: project_id.to_s
+      }
     end
   end
 end

--- a/app/services/code_monitoring_service.rb
+++ b/app/services/code_monitoring_service.rb
@@ -1,0 +1,18 @@
+class CodeMonitoringService
+  def self.call(params)
+    url     = URI(ENV['CODE_MONITOR_URL'])
+    https   = Net::HTTP.new(url.host, url.port)
+    request = Net::HTTP::Post.new(
+      url.path,
+      'Content-Type' => 'application/json'
+    )
+    request.body = params.to_json
+    response = https.request(request)
+    unless response.message == 'OK'
+      puts "------ GitQuest Response Error----TODO : remove these messages later"
+      puts params
+      puts "RESP MESSAGE: #{response.msg}"
+      puts "RESP BODY: #{JSON.parse(response.try(:body))}"
+    end
+  end
+end

--- a/app/views/users/_public_profile.html.haml
+++ b/app/views/users/_public_profile.html.haml
@@ -31,6 +31,8 @@
     %span.add-on @
     = pub.input_field :twitter_handle, style: 'width: 178px;'
   = pub.hint '(Note: Mention only twitter-handle not url)', class: 'skill'
+  = pub.input :gitlab_handle, label: 'GitLab Handle'
+  = pub.input :bitbucket_handle
   = pub.input :blog_url
   = pub.input :linkedin_url
   = pub.input :facebook_url

--- a/app/workers/code_monitoring_worker.rb
+++ b/app/workers/code_monitoring_worker.rb
@@ -1,0 +1,9 @@
+class CodeMonitoringWorker
+  include Sidekiq::Worker
+
+  def perform(params)
+    if !ENV['CODE_MONITOR_URL'].blank? && !Rails.env.development?
+      CodeMonitoringService.call(params)
+    end
+  end
+end

--- a/config/initializers/bson.rb
+++ b/config/initializers/bson.rb
@@ -1,0 +1,11 @@
+module BSON
+  class ObjectId
+    def to_json(*args)
+      to_s.to_json
+    end
+
+    def as_json(*args)
+      to_s.as_json
+    end
+  end
+end

--- a/config/initializers/mongoid.rb
+++ b/config/initializers/mongoid.rb
@@ -1,0 +1,9 @@
+module Mongoid
+  module Document
+    def serializable_hash(options = nil)
+      hash = super(options)
+      hash['id'] = hash.delete('_id') if(hash.has_key?('_id'))
+      hash
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -103,6 +103,8 @@ Rails.application.routes.draw do
   namespace :api, :defaults => {:format => 'json'} do
     namespace :v1 do
       get 'users/info', to: 'users#info'
+      get 'users', to: 'users#index'
+      get 'projects', to: 'project#index'
       get 'team', to: "website#team"
       get 'news', to: "website#news"
       get 'portfolio', to: "website#portfolio"

--- a/spec/acceptance/api/v1/project_controller_spec.rb
+++ b/spec/acceptance/api/v1/project_controller_spec.rb
@@ -1,0 +1,34 @@
+require 'spec_helper'
+require 'rspec_api_documentation/dsl'
+
+resource "Project Apis" do
+  let!(:user) { FactoryGirl.create(:user) }
+  let!(:manager) { create(:manager) }
+  let!(:employees) { create_list(:employee, 2) }
+  let!(:project) { create(:project, company: create(:company), manager_ids: [ manager.id.to_s ]) }
+  let!(:repository) { create(:repository, project_id: project.id) }
+  get '/api/v1/projects' do
+    example 'Get all Project details' do
+      UserProject.create( user_id: employees.first.id,
+                          project_id: project.id,
+                          start_date: DateTime.now - 2 )
+      
+      UserProject.create( user_id: employees.last.id,
+                          project_id: project.id,
+                          start_date: DateTime.now - 2 )
+      user_ids = [{ 'id' => employees.first.id.to_s, 'name' => employees.first.name }, 
+                  { 'id' => employees.last.id.to_s, 'name' => employees.last.name },
+                  { 'id' => manager.id.to_s, 'name' => manager.name }]
+
+      do_request
+      response = JSON.parse(response_body)
+      resp_project = response['projects'].first
+      expect(resp_project['id']).to eq project.id.to_s
+      expect(resp_project['name']).to eq project.name
+      expect(resp_project['repositories'].first['url']).to eq repository.url
+      expect(resp_project['repositories'].first['host']).to eq repository.host
+      expect(resp_project['active_users'].count).to eq 3
+      expect(resp_project['active_users']).to eq user_ids
+    end
+  end
+end

--- a/spec/acceptance/api/v1/users_controller_spec.rb
+++ b/spec/acceptance/api/v1/users_controller_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+require 'rspec_api_documentation/dsl'
+
+resource 'Users Apis' do
+  let!(:employee) { FactoryGirl.create(:user_with_designation, status: 'approved') }
+
+  get '/api/v1/users' do
+    example 'Get all User details' do
+      do_request
+      response = JSON.parse(response_body)
+      users = response['users']
+      expect(users.count).to eq 1
+      expect(users.first['id']).to eq employee.id.to_s
+      expect(users.first['name']).to eq employee.name
+      expect(users.first['email']).to eq employee.email
+      expect(users.first['role']).to eq employee.role
+      expect(users.first['public_profile']['github_handle']).to eq employee.public_profile.github_handle
+      expect(users.first['public_profile']['gitlab_handle']).to eq employee.public_profile.gitlab_handle
+      expect(users.first['public_profile']['bitbucket_handle']).to eq employee.public_profile.bitbucket_handle
+    end
+  end
+end

--- a/spec/factories/public_profiles.rb
+++ b/spec/factories/public_profiles.rb
@@ -9,6 +9,8 @@ FactoryGirl.define do
     technical_skills { ["Angular", "NodeJs", "Python", "React", "UI"] }
     date_of_birth { Date.today }
     github_handle { Faker::Internet.username }
+    gitlab_handle { Faker::Internet.username }
+    bitbucket_handle { Faker::Internet.username }
     blog_url { Faker::Internet.url }
   end
 end

--- a/spec/models/public_profile_spec.rb
+++ b/spec/models/public_profile_spec.rb
@@ -30,4 +30,20 @@ describe PublicProfile do
         to_allow(BLOOD_GROUPS).on(:update)
      }
 
+  context 'Trigger - should call code monitor service' do
+    it 'when Public Profile(github, gitlab, bitbucket handles) is updated' do
+      user = FactoryGirl.build(:user)
+      user.build_public_profile
+      user.public_profile.github_handle = 'jiren'
+      stub_request(:get, "http://localhost?event_type=User+Updated&user_id=#{user.id}&public_profile_details=%7B%22bitbucket_handle%22%3D%3Enil%2C+%22github_handle%22%3D%3E%22jiren%22%2C+%22gitlab_handle%22%3D%3Enil%7D").
+        with(
+          headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
+      user.save
+      expect(user.public_profile.github_handle).to eq('jiren')
+    end
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -37,6 +37,10 @@ RSpec.configure do |config|
     DatabaseCleaner.clean_with(:truncation)
   end
 
+  config.before(:all) do
+    ENV['CODE_MONITOR_URL'] = 'http://localhost'
+  end
+
   config.before(:each) do
     DatabaseCleaner.start
   end


### PR DESCRIPTION
- Add fields gitlab_handle and bitbucket_handle in public_profiles
- Add routes and action methods to render project_info and user_info
- Add Triggers to send event_type, user, repository and project details when
	1. User (irrespective of role) - Resigned, Added or Removed from Project
	2. Project - Active, Disabled or Removed
	3. Repository - Added, Removed
	4. User - Public profile updated(github, gitlab, bitbucket handle)
- Add test cases for new apis project and user info
- Add test cases for Triggers
- Add worker to call endpoint service