### PR TITLE
Timesheet changes

### DIFF
--- a/app/mailers/light_air_user_mailer.rb
+++ b/app/mailers/light_air_user_mailer.rb
@@ -1,0 +1,10 @@
+class LightAirUserMailer < ActionMailer::Base
+  default :from => 'intranet@joshsoftware.com',
+          :reply_to => 'hr@joshsoftware.com'
+ 
+  def send_opt_out_users_report(csv, emails)
+    @date = Date.today.strftime("%d-%m-%Y")
+    attachments["josh_newsletter_opt_out_users_report_#{Date.today}.csv"] = csv
+    mail(subject: "Josh Newsletter Opt-Out Users List till - #{@date}", to: emails)
+  end
+end

--- a/app/mailers/timesheet_remainder_mailer.rb
+++ b/app/mailers/timesheet_remainder_mailer.rb
@@ -6,6 +6,7 @@ class TimesheetRemainderMailer < ActionMailer::Base
     managers_emails = []
     @user = user
     @text = text
+    @projects = user.projects.map(&:name)
     managers_emails = @user.get_managers_emails_for_timesheet
     all_receivers = managers_emails + DEFAULT_TIMESHEET_MANAGERS + ['hr@joshsoftware.com']
     receivers = pending_more_than_threshold ? all_receivers : ['hr@joshsoftware.com']

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -900,7 +900,7 @@ class TimeSheet
   def self.time_sheet_present_for_reminder?(user)
     unless user.time_sheets.present?
       slack_uuid = user.public_profile.slack_handle
-      message = "You haven't filled the timesheet for yesterday. Go ahead and fill it now. You can fill timesheet for past 7 days. If it exceeds 7 days then contact your manager."
+      message = "You haven't filled the timesheet for yesterday. Go ahead and fill it now. You can fill your timesheet <a href='#{'https://' + ENV['DOMAIN_NAME'] + '/time_sheets'}' target='_blank'> here </a> for past 7 days. If it exceeds 7 days then contact your manager."
       text_for_slack = "*#{message}*"
       text_for_email = "#{message}"
       TimesheetRemainderMailer.send_timesheet_reminder_mail(user, slack_uuid, text_for_email).deliver_now!
@@ -931,7 +931,7 @@ class TimeSheet
       slack_handle = user.public_profile.slack_handle
       message1 = "You haven't filled the timesheet from"
       unfilled_timesheet_date = [unfilled_timesheet.to_date, "2020-05-01".to_date].max
-      message2 = "Go ahead and fill it now. You can fill timesheet for past 7 days. If it exceeds 7 days then contact your manager."
+      message2 = "Go ahead and fill it now. You can fill your timesheet <a href='#{'https://' + ENV['DOMAIN_NAME'] + '/time_sheets'}' target='_blank'> here </a> for past 7 days. If it exceeds 7 days then contact your manager."
       text_for_slack = "*#{message1} #{unfilled_timesheet_date}. #{message2}*"
       text_for_email = "#{message1} #{unfilled_timesheet_date}. #{message2}"
       pending_more_than_threshold = (Date.today - unfilled_timesheet_date) > PENDING_THRESHOLD

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -237,7 +237,7 @@ class User
   end
 
   def projects
-    project_ids = user_projects.where(end_date: nil).pluck(:project_id)
+    project_ids = user_projects.where(active: true, end_date: nil).pluck(:project_id)
     Project.in(id: project_ids)
   end
 

--- a/app/views/light_air_user_mailer/send_opt_out_users_report.html.haml
+++ b/app/views/light_air_user_mailer/send_opt_out_users_report.html.haml
@@ -1,0 +1,8 @@
+%span Hi,
+%br
+%br
+Attach herewith is the list of user who opted out from the newsletter till #{@date}. 
+Please let us know if you have any queries.
+%br
+%br
+Thanks

--- a/app/views/time_sheets/index.html.haml
+++ b/app/views/time_sheets/index.html.haml
@@ -6,7 +6,6 @@
     = text_field_tag :to_date, params[:to_date], class: "form-control datepicker", placeholder: "To Date", value: @to_date, style: "height: 2em;"
     = submit_tag "Search", class: "btn btn-primary"
     .pull-right
-      - if [ROLE[:intern], ROLE[:employee], "Manager"].include?(current_user.role)
-        = link_to '', new_time_sheet_path(user_id: current_user.id, from_date: @from_date, to_date: @to_date), "data-toggle" => "tooltip", title: 'Add Timesheet', class: "icon-plus add-timesheet-icon"
+      = link_to '', new_time_sheet_path(user_id: current_user.id, from_date: @from_date, to_date: @to_date), "data-toggle" => "tooltip", title: 'Add Timesheet', class: "icon-plus add-timesheet-icon"
 .timesheet_report
   = render 'time_sheets/timesheet_report_view', timesheet_reports: @timesheet_report

--- a/app/views/timesheet_remainder_mailer/send_timesheet_reminder_mail.html.haml
+++ b/app/views/timesheet_remainder_mailer/send_timesheet_reminder_mail.html.haml
@@ -2,7 +2,13 @@
   Hello #{@user.name},
   %br
   %br
-  #{@text}
+  #{@text.html_safe}
+  %br
+  %br
+  Here is the list of your projects: 
+  - @projects.each_with_index do |project, index|
+    %br
+    #{index + 1}. #{project}
   %br
   %br
   Thanks

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -81,6 +81,10 @@ every :month, :at => 'start of the month at 09:30am' do
   rake "user_without_timesheet:monthly_report"
 end
 
+every :month, :at => 'start of the month at 09:30am' do
+  rake 'light_air:send_opt_out_users_report'
+end
+
 every :day, :at => '10:00am' do
   rake "timesheet_reminder:timesheet_for_diffrent_project"
 end

--- a/lib/tasks/light_air.rake
+++ b/lib/tasks/light_air.rake
@@ -1,0 +1,38 @@
+require 'csv'
+namespace :light_air do
+  desc 'Send report of Opt-Out Users to HR every month'
+  task :send_opt_out_users_report => :environment do
+    
+    user_reports = []
+    opt_out_users = Light::User.where(sidekiq_status: 'Unsubscribed')
+                               .order_by(:unsubscribed_at.desc)           
+    opt_out_users.each do |u|
+      user_reports << [ u.username,
+                        u.email_id,
+                        u.sidekiq_status,
+                        date_format(u.subscribed_at),
+                        date_format(u.unsubscribed_at) ]
+    end
+    
+    hr_emails = User.where(role: 'HR', status: 'approved').map(&:email)
+    user_reports_csv = generate_csv(user_reports)
+
+    LightAirUserMailer.send_opt_out_users_report(user_reports_csv, hr_emails).deliver_now!
+  end
+
+  def date_format(date)
+    date.present? ? date.strftime("%d-%m-%Y") : 'N/A'
+  end
+
+  def generate_csv(user_reports)
+    headers = ['Name', 'Email Id', 'Status', 'Opt-In At', 'Opt-Out At']
+    csv = 
+      CSV.generate(headers: true) do |csv|
+        csv << headers
+        user_reports.each do |user|
+          csv << user
+        end
+      end
+    csv
+  end
+end


### PR DESCRIPTION
- Remove restriction to add timesheet for Admin and HR
- Display project names in timesheet reminder mail
- Add task to send report of LightAir opt-out users
- Add link ref to timesheet list page in timesheet reminder mail