### PR TITLE
Employees Working Hour Report

### DIFF
--- a/app/mailers/weekly_timesheet_report_mailer.rb
+++ b/app/mailers/weekly_timesheet_report_mailer.rb
@@ -22,6 +22,19 @@ class WeeklyTimesheetReportMailer < ActionMailer::Base
     )
   end
 
+  def send_employees_working_hour_report(csv, start_date)
+    attachments["employees_working_hour_report_#{Date.today}.csv"] = csv
+    hr_emails = User.approved.where(role: 'HR').collect(&:email)
+    emails = [ 'sameert@joshsoftware.com', 
+               'shailesh.kalekar@joshsoftware.com',
+               hr_emails ].flatten
+    @start_date = start_date.strftime('%d %B')
+    mail(
+      subject: "Employee Report - Worked More than 9 Hours During (#{start_date.strftime('%d %B')} - #{(Date.today - 1).strftime('%d %B')})",
+      to: emails
+    )
+  end
+
   def send_report_who_havent_filled_timesheet( options = {} )
     @text = options[:text]
     attachments["Employees- Not Filled Timesheet.csv"] = options[:csv]

--- a/app/views/weekly_timesheet_report_mailer/send_employees_working_hour_report.haml
+++ b/app/views/weekly_timesheet_report_mailer/send_employees_working_hour_report.haml
@@ -1,0 +1,7 @@
+%span Hello Admins,
+%br
+%br
+%span Please find attached timesheet report of the employees who worked for more than 9 hours a day in the last week (#{@start_date} till today).
+%br
+%br
+%span Thanks

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -109,6 +109,10 @@ every :monday, :at => '09:00am' do
   rake "fetch_rollbar_statistics"
 end
 
+every :monday, :at => '09:30am' do
+  rake 'employees_working_hour_report'
+end
+
 every :tuesday, :at => '09:00am' do
   rake 'weekend_timesheet_report'
 end

--- a/lib/tasks/employees_working_hour_report.rake
+++ b/lib/tasks/employees_working_hour_report.rake
@@ -1,0 +1,6 @@
+desc 'Send timesheet report of employees who worked more than 9 hours a day over last week'
+task :employees_working_hour_report => :environment do
+  dates = 7.days.ago.to_date..(Date.today - 1)
+  duration = 540 # mintues
+  TimeSheet.generate_and_send_employees_working_hour_report(dates, duration)
+end


### PR DESCRIPTION
- Schedule task to send report every week on Monday morning
- Add methods to generate report of Employees who worked more than 9
hours a day over last week
- Add test cases accordingly