### PR TITLE
Repository API Triggers

### DIFF
--- a/app/models/public_profile.rb
+++ b/app/models/public_profile.rb
@@ -40,9 +40,28 @@ class PublicProfile
     #We need to manually set the slug because user does not have field 'name' in its model and delegated to public_profile
     user.set_slug
     self.user.set_details("dob", self.date_of_birth) if self.date_of_birth_changed? #set the dob_day and dob_month
+    call_monitor_service if (changes.keys & ['github_handle', 'gitlab_handle', 'bitbucket_handle']).length > 0
   end
 
   # after_update :delete_team_cache, :send_email_to_hr, if: Proc.new{ updated_at_changed? && !slack_handle_changed? }
+
+  def call_monitor_service
+    CodeMonitoringService.call(monitor_service_params)
+  end
+
+  def monitor_service_params
+    {
+      event_type:             'User Updated',
+      user_id:                user.id.to_s,
+      public_profile_details: self.as_json(public_profile_fields)
+    }
+  end
+
+  def public_profile_fields
+    {
+      only: [:gitlab_handle, :bitbucket_handle, :github_handle]
+    }
+  end
 
   def name
     "#{first_name} #{last_name}"

--- a/app/models/repository.rb
+++ b/app/models/repository.rb
@@ -18,4 +18,55 @@ class Repository
   field :rollbar_access_token
   has_many :rollbar_statistics, dependent: :destroy
   validates_uniqueness_of :code_climate_id, allow_blank: true, allow_nil: true
+
+  after_create do
+    call_monitor_service('created')
+  end
+
+  before_destroy do
+    call_monitor_service('destroyed')
+  end
+
+  # before_save do
+  #   # for change in url, name, host
+  #   if persisted? and (changes.keys & ['url', 'name', 'host']).length > 0
+  #     call_monitor_service('updated')
+  #   end
+  # end
+
+  private
+
+  def call_monitor_service(event)
+    CodeMonitoringService.call(monitor_service_params(event))
+  end
+
+  def monitor_service_params(event)
+    data = {
+      event_type:         '',
+      repository_id:      id.to_s,
+      repository_url:     url,
+      project_id:         project_id.to_s,
+      repository_details: self.as_json(repository_fields)
+    }
+    case event
+    when 'created'
+      data[:event_type] = 'Repository Added'
+    when 'destroyed'
+      data[:event_type] = 'Repository Removed'
+      data[:project_id] = project_id_was.to_s
+      data.delete(:repository_details)
+    # when 'updated'
+    #   data[:event_type] = 'Repository Update'
+    end
+    data
+  end
+
+  def repository_fields
+    {
+      only: [
+        :name, :host, :code_climate_id, :maintainability_badge,
+        :test_coverage_badge, :visibility, :rollbar_access_token
+      ]
+    }
+  end
 end

--- a/app/views/users/_public_profile.html.haml
+++ b/app/views/users/_public_profile.html.haml
@@ -33,6 +33,8 @@
   = pub.hint '(Note: Mention only twitter-handle not url)', class: 'skill'
   = pub.input :gitlab_handle, label: 'GitLab Handle'
   = pub.input :bitbucket_handle
+  = pub.input :gitlab_handle, label: 'GitLab Handle'
+  = pub.input :bitbucket_handle
   = pub.input :blog_url
   = pub.input :linkedin_url
   = pub.input :facebook_url

--- a/app/views/users/_public_profile.html.haml
+++ b/app/views/users/_public_profile.html.haml
@@ -33,8 +33,6 @@
   = pub.hint '(Note: Mention only twitter-handle not url)', class: 'skill'
   = pub.input :gitlab_handle, label: 'GitLab Handle'
   = pub.input :bitbucket_handle
-  = pub.input :gitlab_handle, label: 'GitLab Handle'
-  = pub.input :bitbucket_handle
   = pub.input :blog_url
   = pub.input :linkedin_url
   = pub.input :facebook_url

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -119,6 +119,7 @@ task :deploy => :environment do
       unless nocron
         queue "cd #{deploy_to}/current && bundle exec whenever -i intranet_whenever_tasks --update-crontab --set 'environment=#{env}'"
       end
+      queue "echo '#{settings.branch}' > #{deploy_to}/#{settings.current_path}/branch_deployed.txt"
       queue "touch #{deploy_to}/#{current_path}/tmp/restart.txt"
       if env == 'production'
         queue "sudo monit restart sidekiq"

--- a/spec/models/public_profile_spec.rb
+++ b/spec/models/public_profile_spec.rb
@@ -30,4 +30,20 @@ describe PublicProfile do
         to_allow(BLOOD_GROUPS).on(:update)
      }
 
+  context 'Trigger - should call code monitor service' do
+    it 'when Public Profile(github, gitlab, bitbucket handles) is updated' do
+      user = FactoryGirl.build(:user)
+      user.build_public_profile
+      user.public_profile.github_handle = 'jiren'
+      stub_request(:get, "http://localhost?event_type=User+Updated&user_id=#{user.id}&public_profile_details=%7B%22bitbucket_handle%22%3D%3Enil%2C+%22github_handle%22%3D%3E%22jiren%22%2C+%22gitlab_handle%22%3D%3Enil%7D").
+        with(
+          headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
+      user.save
+      expect(user.public_profile.github_handle).to eq('jiren')
+    end
+  end
 end

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -21,6 +21,59 @@ describe Repository do
     expect(repository.errors.full_messages).to eq(["Project can't be blank"])
   end
 
+  context 'Trigger - should call code monitor service' do
+    it 'when Repository is added' do
+      project = FactoryGirl.create(:project)
+      repository = FactoryGirl.build(:repository, project: project)
+      params = {
+        event_type:         'Repository Added',
+        repository_id:      repository.id,
+        repository_url:     repository.url,
+        project_id:         repository.project.id,
+        repository_details: repository.as_json({
+          only: [
+            :name, :host, :code_climate_id, :maintainability_badge,
+            :test_coverage_badge, :visibility, :rollbar_access_token
+          ]
+        })
+      }
+      uri = URI('http://localhost')
+      uri.query = URI.encode_www_form(params)
+      stub_request(:get, uri).
+        with(
+          headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
+      expect(repository.new_record?).to eq(true)
+      repository.save
+      expect(repository).to be_valid
+    end
+
+    it 'when Repository is removed' do
+      project = FactoryGirl.create(:project)
+      repository = FactoryGirl.create(:repository, project: project)
+      params = {
+        event_type:         'Repository Removed',
+        repository_id:      repository.id,
+        repository_url:     repository.url,
+        project_id:         repository.project.id
+      }
+      uri = URI('http://localhost')
+      uri.query = URI.encode_www_form(params)
+      stub_request(:get, uri).
+        with(
+          headers: {
+            'Accept'=>'*/*',
+            'User-Agent'=>'Ruby'
+          }).
+        to_return(status: 200, body: "", headers: {})
+      repository.destroy
+      expect(Repository.count).to eq 0
+    end
+  end
+
   it 'should not create a Repository with invalid host' do
     project = FactoryGirl.create(:project)
     repository = FactoryGirl.build(:repository, project: project)

--- a/spec/models/repository_spec.rb
+++ b/spec/models/repository_spec.rb
@@ -22,15 +22,28 @@ describe Repository do
   end
 
   context 'Trigger - should call code monitor service' do
-    it 'when Repository is added' do
-      project = FactoryGirl.create(:project)
-      repository = FactoryGirl.build(:repository, project: project)
+    before do
+      # for creating project
+      project = FactoryGirl.build(:project)
+      stub_request(:get, "http://localhost/?event_type=Project%20Active&project_id=#{project.id}").
+         with(
+           headers: {
+          'Accept'=>'*/*',
+          'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+          'Host'=>'localhost',
+          'User-Agent'=>'Ruby'
+           }).
+         to_return(status: 200, body: "", headers: {})
+      project.save
+
+      # for addition of repository
+      @repository = FactoryGirl.build(:repository, project: project)
       params = {
         event_type:         'Repository Added',
-        repository_id:      repository.id,
-        repository_url:     repository.url,
-        project_id:         repository.project.id,
-        repository_details: repository.as_json({
+        repository_id:      @repository.id,
+        repository_url:     @repository.url,
+        project_id:         @repository.project.id,
+        repository_details: @repository.as_json({
           only: [
             :name, :host, :code_climate_id, :maintainability_badge,
             :test_coverage_badge, :visibility, :rollbar_access_token
@@ -43,33 +56,40 @@ describe Repository do
         with(
           headers: {
             'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host'=>'localhost',
             'User-Agent'=>'Ruby'
           }).
         to_return(status: 200, body: "", headers: {})
-      expect(repository.new_record?).to eq(true)
-      repository.save
-      expect(repository).to be_valid
-    end
 
-    it 'when Repository is removed' do
-      project = FactoryGirl.create(:project)
-      repository = FactoryGirl.create(:repository, project: project)
+      # for removal of repository
       params = {
         event_type:         'Repository Removed',
-        repository_id:      repository.id,
-        repository_url:     repository.url,
-        project_id:         repository.project.id
+        repository_id:      @repository.id,
+        repository_url:     @repository.url,
+        project_id:         @repository.project.id
       }
-      uri = URI('http://localhost')
       uri.query = URI.encode_www_form(params)
       stub_request(:get, uri).
         with(
           headers: {
             'Accept'=>'*/*',
+            'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3',
+            'Host'=>'localhost',
             'User-Agent'=>'Ruby'
           }).
         to_return(status: 200, body: "", headers: {})
-      repository.destroy
+    end
+
+    it 'when Repository is added' do
+      expect(@repository.new_record?).to eq(true)
+      @repository.save
+      expect(@repository).to be_valid
+    end
+
+    it 'when Repository is removed' do
+      @repository.save
+      @repository.destroy
       expect(Repository.count).to eq 0
     end
   end


### PR DESCRIPTION
- Added triggers to send event_type, Public Profile and Repository details when
i. User - Public profile updated(github, gitlab, bitbucket handle)
ii. Repository - Added, Removed
- Add test cases for new apis triggers