### PR TITLE
Corrects regex replace for github feed

### DIFF
--- a/app/views/users/_github_profile.html.haml
+++ b/app/views/users/_github_profile.html.haml
@@ -1,5 +1,5 @@
 %ul.media-list
   - github_entries.each do |entry|
     .project-name
-      - entry.content.gsub!( %r{<a href=\"/},'<a href="https://github.com/')
+      - entry.content.gsub!( %r{<a(.*)href=\"/},'<a \1 href="https://github.com/')
       = raw entry.content


### PR DESCRIPTION
This PR corrects the partial regex replace for the full domain from GitHub feed.

Here, we are using regex backreference.

Resource: https://dev.to/thespectator/partial-regex-match-replace-using-gsub-9b8-temp-slug-8810088?preview=c3c6dfa9bfc88c827d5d21c3b03357731c124a8ff0257d925b19bf514e64e318d91a27db01f801400792b5ae0bcfe5489cd1d40e7a3501a2b8dedc9e