### PR TITLE
Skip project not assigned mail

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -144,8 +144,8 @@ class UsersController < ApplicationController
 
   def user_params
     params.require(:user).permit(:status, :role, :visible_on_website, :website_sequence_number,
-      :allow_backdated_timesheet_entry, employee_detail_attributes: [:id, :employee_id, :location,
-      :date_of_relieving, :designation, :description, :is_billable, :designation_track, :notification_emails => [] ],
+      :allow_backdated_timesheet_entry, employee_detail_attributes: [:id, :employee_id, :location, :date_of_relieving,
+      :designation, :description, :is_billable, :skip_unassigned_project_ts_mail, :designation_track, :notification_emails => [] ],
       attachments_attributes: [:id, :name, :document, :_destroy]
     )
   end
@@ -189,9 +189,11 @@ class UsersController < ApplicationController
 
   def get_bonusly_messages
     bonusly = Api::Bonusly.new(BONUSLY_TOKEN)
-    bonusly.bonusly_messages(start_time: Date.today.strftime('%B+1st'),
-                             end_time:   Date.today.end_of_month.strftime('%B+%dst'),
-                             user_email: @user.email)
+    bonusly.bonusly_messages(
+      start_time: Date.today.strftime('%B+1st'),
+      end_time:   Date.today.end_of_month.strftime('%B+%dst'),
+      user_email: @user.email
+    )
   end
 
   def get_github_feed

--- a/app/models/employee_detail.rb
+++ b/app/models/employee_detail.rb
@@ -11,13 +11,13 @@ class EmployeeDetail
   field :available_leaves, type: Integer, default: 0
   field :description
   field :is_billable, type: Boolean, default: false
+  field :skip_unassigned_project_ts_mail, type: Boolean, default: false
   field :designation_track, type: String, default: DESIGNATION_TRACKS.first
   field :location
 
   belongs_to :designation
 
   validates :employee_id, uniqueness: true
-  #validates :employee_id, numericality: {greater_than_or_equal_to: 9000}, if: :assign_new_usa_id?
   #validates :designation_track, presence: true
   validates :available_leaves, numericality: {greater_than_or_equal_to: 0}
   after_update :delete_team_cache, if: Proc.new{ updated_at_changed? }
@@ -44,11 +44,5 @@ class EmployeeDetail
   def add_rejected_leave(number_of_days)
     remaining_leaves = available_leaves + number_of_days
     self.update_attribute(:available_leaves, remaining_leaves)
-  end
-
-  def assign_new_usa_id?
-    # For Sachin's record we are keeping his employee ID as it is
-    # For all other USA employees ID must be above 9000
-    employee_id.nil? and location == "Plano" ? true : false
   end
 end

--- a/app/models/time_sheet.rb
+++ b/app/models/time_sheet.rb
@@ -1095,18 +1095,18 @@ class TimeSheet
 
   def self.get_users_and_timesheet_who_have_filled_timesheet_for_different_project
     activity_ids = Project.where(is_activity: true).pluck(:id)
-    User.approved.each do | user |
+    User.approved.where('employee_detail.skip_unassigned_project_ts_mail': false).each do | user |
       user_timesheet = []
       date           = Date.yesterday
       time_sheets    = user.time_sheets.where(
-        :created_at => date.beginning_of_day..date.end_of_day,
+        created_at: date.beginning_of_day..date.end_of_day,
         :project_id.nin => activity_ids
       )
       next if time_sheets.empty?
       time_sheets.each do|time_sheet|
         time_sheet_data = {}
         next if user.user_projects.where(project_id: time_sheet.project_id).exists?
-        duration = DURATION_HASH[time_sheet.duration].nil? ? time_sheet.duration.to_s + "mins" : DURATION_HASH[time_sheet.duration]
+        duration = DURATION_HASH[time_sheet.duration].nil? ? time_sheet.duration.to_s + 'mins' : DURATION_HASH[time_sheet.duration]
         time_sheet_data = {
           project_name: time_sheet.project.name,
           date:         time_sheet.date,

--- a/app/views/users/_employee_detail.html.haml
+++ b/app/views/users/_employee_detail.html.haml
@@ -7,10 +7,17 @@
     = e.input :description, as: :text, input_html: {class: 'text-description'}
     = e.input :date_of_relieving, input_html: { type: 'date', class: 'date-picker', value: @user.employee_detail.date_of_relieving.try(:strftime, "%Y-%m-%d")}
     = e.input :notification_emails, collection: @emails, input_html: {class: 'notification_emails', multiple: true, style: "width:300px;", "data-placeholder" => "You can add multiple emails"}
-    = e.label "Is Billable"
-    .make-switch{ tabindex: 0, "data-on": "success", "data-off": "warning", "data-on-label": "Yes", "data-off-label": "No"}
+    = e.label 'Is Billable'
+    .make-switch{ tabindex: 0, 'data-on': 'success', 'data-off': 'warning', 'data-on-label': 'Yes', 'data-off-label': 'No'}
       = e.check_box :is_billable, {}, 'Yes', 'No'
-  = f.input :project_ids, collection: @projects, input_html: {class: 'project_ids', multiple: true, style: "width:300px;", tabindex: 0, "data-placeholder" => "Add projects"}, label: "Projects", disabled: true
+    %br
+    %br
+    = e.label 'Skip Unassigned Project Timesheet Mail'
+    .make-switch{'data-on': 'success', 'data-off': 'warning', 'data-on-label': 'Yes', 'data-off-label': 'No'}
+      = e.check_box :skip_unassigned_project_ts_mail, {}, 'Yes', 'No'
+    %br
+    %br
+  = f.input :project_ids, collection: @projects, input_html: {class: 'project_ids', multiple: true, style: 'width:300px;', tabindex: 0, 'data-placeholder': 'Add projects'}, label: 'Projects', disabled: true
   = f.submit :save, class: "btn controls"
 - if @notify_users
   %h4 Current Notification to

--- a/spec/factories/employee_details.rb
+++ b/spec/factories/employee_details.rb
@@ -1,8 +1,9 @@
 FactoryGirl.define do
   factory :employee_detail do
     designation
-    location {"Pune"}
+    location { 'Pune' }
     available_leaves { 24 }
     notification_emails { ['hr@testcompany.com'] }
+    skip_unassigned_project_ts_mail { false }
   end
 end

--- a/spec/helpers/user_helper_spec.rb
+++ b/spec/helpers/user_helper_spec.rb
@@ -10,6 +10,6 @@ require 'spec_helper'
 #     end
 #   end
 # end
-describe UserHelper do
+describe UsersHelper do
   # pending "add some examples to (or delete) #{__FILE__}"
 end


### PR DESCRIPTION
- Added new field as unassigned_project in employee_details model default true
- Added send unassigned project mail button in employee details template
- Added a check before sending project not assigned mail to check unassigned_project flag and if the flag is set to false the mail will not be sent
- Modified test-cases for the above.