### PR TITLE
Fixed document download notification issue

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -180,12 +180,16 @@ class UsersController < ApplicationController
   def authorize_document_download
     @attachment = Attachment.where(id: params[:id]).first
     @document = @attachment.document
-    message = "You are not authorize to perform this action"
-    (current_user.can_download_document?(@user, @attachment)) || (flash[:error] = message; redirect_to root_url)
+    message = 'You are not authorize to perform this action'
+    (current_user.can_download_document?(@user, @attachment)) ||
+    (flash[:error] = message; redirect_to root_url)
   end
 
   def notify_document_download
-    UserMailer.delay.download_notification(current_user.id, @attachment.name)
+    UserMailer.delay.download_notification(
+      current_user.id,
+      @attachment.name
+    ) unless DOCUMENT_MANAGEMENT.include?(current_user.role)
   end
 
   def get_bonusly_messages

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -176,7 +176,8 @@ class User
 
   def can_download_document?(user, attachment)
     user = user.nil? ? self : user
-    (["Admin", "Finance", "Manager", "Super Admin"].include?(self.role)) || attachment.user_id == user.id
+    (DOCUMENT_MANAGEMENT.include?(self.role)) ||
+    attachment.user_id == user.id
   end
 
   def can_change_role_and_status?(user)
@@ -305,7 +306,7 @@ class User
       end_date: nil,
       time_sheet: true
     ).pluck(:project_id)
-    
+
     manager_ids = Project.in(id: project_ids).pluck(:manager_ids).flatten.uniq
     User.in(id: manager_ids, status: STATUS[:approved]).pluck(:email)
   end

--- a/app/views/users/public_profile.html.haml
+++ b/app/views/users/public_profile.html.haml
@@ -6,28 +6,29 @@
 %div.tabbable
   %ul.nav.nav-tabs
     %li.active.public-tab
-      %a{data: {toggle: 'tab'}, href: "#public"} 
+      %a{data: {toggle: 'tab'}, href: '#public'}
         Public Profile
     %li.private-tab
-      %a{data: {toggle: "tab"}, href: "#private"} 
+      %a{data: {toggle: 'tab'}, href: '#private'}
         Personal Details
     - if can? :edit, User
       %li.emp-details-tab
-        %a{data: {toggle: "tab"}, href: "#emp-details"}
+        %a{data: {toggle: 'tab'}, href: '#emp-details'}
           Employee details
-    %li.document-tab
-      %a{data: {toggle: "tab"}, href: "#document"}
-        Documents
-  
+    - if DOCUMENT_MANAGEMENT.include?(current_user.role) || current_user == @user
+      %li.document-tab
+        %a{data: {toggle: 'tab'}, href: '#document'}
+          Documents
+
   .tab-content
     .tab-pane.active#public
-      = render partial: "public_profile"
+      = render partial: 'public_profile'
     .tab-pane#private
-      = render partial: "private_profile"
+      = render partial: 'private_profile'
     .tab-pane#emp-details
-      = render partial: "employee_detail"
+      = render partial: 'employee_detail'
     .tab-pane#document
-      = render partial: "document"
+      = render partial: 'document'
 
 :javascript
   error = #{!@private_profile.errors.full_messages.empty?}

--- a/config/initializers/global_constants.rb
+++ b/config/initializers/global_constants.rb
@@ -38,6 +38,8 @@ DEFAULT_TIMESHEET_MANAGERS = []
 MANAGEMENT = ["Admin", "HR", "Manager", "Finance"]
 TIMESHEET_MANAGEMENT = ['Admin', 'HR', 'Manager']
 
+DOCUMENT_MANAGEMENT = ['Super Admin', 'Admin', 'HR']
+
 DAILY_OFFICE_ENTRY_LIMIT = 30
 
 OFFICE_ENTRY_PASS_MAIL_RECEPIENT=["shailesh.kalekar@joshsoftware.com", "sameert@joshsoftware.com", "hr@joshsoftware.com"]

--- a/spec/controllers/attachments_controller_spec.rb
+++ b/spec/controllers/attachments_controller_spec.rb
@@ -41,8 +41,17 @@ describe AttachmentsController do
   describe '#download_document' do
     context 'document is visible to all' do
       it 'should return the document' do
-        get :download_document, { id: public_doc.id }
+        get :download_document, {id: public_doc.id}
         expect(response).to be_success
+      end
+    end
+
+    it 'should not send notification mail if user downloads company document' do
+      Sidekiq::Testing.inline! do
+        ActionMailer::Base.deliveries = []
+        get :download_document, {id: public_doc.id}
+        expect(response).to be_success
+        expect(ActionMailer::Base.deliveries.count).to eq(0)
       end
     end
   end


### PR DESCRIPTION
Changes in document download and its notification mail
- Notification to be sent only if any employee download own document unless that employee is HR or admin
- Authorised people who can download employee document
	1. Himself/Herself
	2. HR
	3. Admin
- Modified the testcases for the same