### PR TITLE
joining date validation

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -76,6 +76,8 @@ class UsersController < ApplicationController
         #UserMailer.delay.verification(@user.id)
         redirect_to public_profile_user_path(@user)
       else
+        tab = (profile == "private_profile") ? 'Private Profile' : 'Public Profile'
+        flash[:error] = "#{tab}: Error #{@user.generate_errors_message}"
         render "public_profile"
       end
     end

--- a/app/models/private_profile.rb
+++ b/app/models/private_profile.rb
@@ -18,7 +18,8 @@ class PrivateProfile
   has_many :addresses, autosave: true
 
   validates :date_of_joining, presence: true, if: :check_status_and_role?, on: :update
-  validates :previous_work_experience,:allow_blank => true, numericality: { only_integer: true }
+  validate :validate_date_of_joining, if: 'date_of_joining_changed?'
+  validates :previous_work_experience, :allow_blank => true, numericality: { only_integer: true, greater_than_or_equal_to: 0}
 
   accepts_nested_attributes_for :addresses
   accepts_nested_attributes_for :contact_persons
@@ -29,6 +30,10 @@ class PrivateProfile
       user.assign_leave('DOJ Updated') if user.eligible_for_leave?
       user.set_details("doj", self.date_of_joining)
     end
+  end
+
+  def validate_date_of_joining
+    errors.add(:date_of_joining, 'should not a date from future.') if date_of_joining.try(:future?)
   end
 
   def check_status_and_role?

--- a/app/views/users/_private_profile.html.haml
+++ b/app/views/users/_private_profile.html.haml
@@ -18,7 +18,7 @@
         - if can? :edit, User
           = pri.input :end_of_probation, input_html: { type: 'date', class: 'date-picker', value: @private_profile.end_of_probation.try(:strftime, "%Y-%m-%d")}, label: 'End of probation (Date after 90 days)'
       %td
-        = pri.input :previous_work_experience, placeholder: 'No of Months', input_html: {type: 'number'}, label: 'Previous Work Experience (in Months)'
+        = pri.input :previous_work_experience, placeholder: 'No of Months', input_html: {type: 'number', min: 0}, label: 'Previous Work Experience (in Months)'
     %tr
       %td
         = pri.input :previous_company, as: :text

--- a/spec/models/private_profile_spec.rb
+++ b/spec/models/private_profile_spec.rb
@@ -47,6 +47,26 @@ describe PrivateProfile do
     end
   end
 
+  context 'Validation of joining date' do
+    let!(:user) { FactoryGirl.create(:user) }
+
+    before do
+      @private_profile = user.private_profile
+    end
+
+    it 'should fails because joining date is future date' do
+      @private_profile.date_of_joining = Date.tomorrow
+      expect(user.valid?).to be_falsy
+      expect(@private_profile.errors.full_messages).to eq(
+        ['Date of joining should not a date from future.']
+      )
+    end
+
+    it 'should pass because joining date is current date or past date' do
+      expect(user.valid?).to_not be_falsy 
+    end
+  end
+
   context 'validation should not trigger' do
     let!(:user){ FactoryGirl.create(:user) }
 


### PR DESCRIPTION
Add Joining date validation, when employees create or update the joining date it must be today or past date. Don't be the feature date.