### PR TITLE
assign_default_manager

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -314,7 +314,25 @@ class User
 
   def get_managers_names
     manager_ids = projects.pluck(:manager_ids).flatten.uniq
-    User.in(id: manager_ids, status: STATUS[:approved]).collect(&:name)
+    user_role = ['Finance', 'HR', 'Admin']
+    user_designation = [
+      'Senior Accountant', 'Assistant Vice President - Sales',
+      'Senior Manager- Sales', 'Assistant Manager - Accounts'
+    ]
+
+    if manager_ids.compact.blank?
+      emp_designation = employee_detail.designation.try(:name)
+      if employee_detail.try(:location).eql?(LOCATIONS[0]) #Bengaluru
+        return User.where(email: CUSTOM_MANAGERS[:bengaluru]).collect(&:name)
+      elsif user_role.include?(role) || user_designation.include?(emp_designation)
+        return User.where(email: CUSTOM_MANAGERS[:admin]).collect(&:name)
+      elsif UI_UX_DESIGNATION.include?(emp_designation)
+        return User.where(email: CUSTOM_MANAGERS[:ui_ux]).collect(&:name)
+      else
+        return User.where(email: CUSTOM_MANAGERS[:default]).collect(&:name)
+      end
+    end
+    User.in(id: manager_ids).collect(&:name)
   end
 
   def self.get_hr_emails

--- a/config/initializers/global_constants.rb
+++ b/config/initializers/global_constants.rb
@@ -51,3 +51,8 @@ DAILY_OFFICE_ENTRY_LIMIT = 30
 OFFICE_ENTRY_PASS_MAIL_RECEPIENT=["shailesh.kalekar@joshsoftware.com", "sameert@joshsoftware.com", "hr@joshsoftware.com"]
 
 ROLLBAR_ISSUES_URL = 'https://api.rollbar.com/api/1/items'
+
+CUSTOM_MANAGERS = { 
+  bengaluru: 'amit.singh@joshsoftware.com', ui_ux: 'sai@joshsoftware.com',
+  admin: 'shailesh.kalekar@joshsoftware.com', default: 'sameert@joshsoftware.com'
+}

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -561,4 +561,56 @@ describe User do
       expect(user.experience_as_of_today).to eq(experience)
     end
   end
+
+  describe 'get_managers_names' do
+    let!(:user) { FactoryGirl.create(:user) }
+
+    it 'should return manager name of respective employee' do
+      project = FactoryGirl.create(:project)
+      manager_one = FactoryGirl.create(:manager)
+      manager_two = FactoryGirl.create(:manager)
+      user_project = FactoryGirl.create(:user_project,
+        user: user,
+        project: project,
+        start_date: Date.today - 2
+      )
+      project.managers << manager_one
+      project.managers << manager_two
+      managers_names = user.get_managers_names
+      expect(managers_names.count).to eq(2)
+      expect(managers_names[0]).to eq(manager_one.name)
+      expect(managers_names[1]).to eq(manager_two.name)
+    end
+
+    context 'if emp has not assigned any project then should return default manager name and if' do
+
+      it 'employee work in Bengaluru' do
+        user.employee_detail.set(location: LOCATIONS[0]) #Bengaluru
+        default_manager = FactoryGirl.create(:user, email: CUSTOM_MANAGERS[:bengaluru])
+        managers_names = user.get_managers_names
+        expect(managers_names.count).to eq(1)
+      end
+
+      it 'employee role is admin' do
+        user.set(role: ROLE[:admin])
+        default_manager = FactoryGirl.create(:user, email: CUSTOM_MANAGERS[:admin], role: ROLE[:admin], status: STATUS[:approved])
+        managers_names = user.get_managers_names
+        expect(managers_names.count).to eq(1)
+      end
+
+      it 'employee designation is UI/UX Designer' do
+        designation = FactoryGirl.create(:designation, name: UI_UX_DESIGNATION[1])  # 'UI/UX Designer'
+        user.employee_detail.designation = designation
+        default_manager = FactoryGirl.create(:user, email: CUSTOM_MANAGERS[:ui_ux])
+        managers_names = user.get_managers_names
+        expect(managers_names.count).to eq(1)
+      end
+
+      it 'employee has no any role and designation then assign default manager' do
+        default_manager = FactoryGirl.create(:user, email: CUSTOM_MANAGERS[:default])
+        managers_names = user.get_managers_names
+        expect(managers_names.count).to eq(1)
+      end
+    end
+  end
 end


### PR DESCRIPTION
 All emp is not assigned to the project. so in leave application manager's name goes empty for such emp.
If the manager name is not assigned then
Set manager name same as “shailesh.kalekar@joshsoftware.com” for all emp from HR, Admin, Sales, Accounts.
If emp is from B’lore set it as “amit.kumar@joshsoftare.com”
For UX/UI set this to “sai@joshsoftware.com”
default set manager name as “sameert@joshsoftware.com”