### PR TITLE
Add validation on InternShip start and end date

### DIFF
--- a/app/models/private_profile.rb
+++ b/app/models/private_profile.rb
@@ -5,6 +5,8 @@ class PrivateProfile
   field :personal_email
   field :passport_number
   field :qualification
+  field :internship_start_date, type: Date
+  field :internship_end_date, type: Date
   field :date_of_joining,  :type => Date
   field :end_of_probation, :type => Date
   field :work_experience
@@ -17,6 +19,7 @@ class PrivateProfile
   embeds_many :contact_persons
   has_many :addresses, autosave: true
 
+  validate :validate_internship_date
   validates :date_of_joining, presence: true, if: :check_status_and_role?, on: :update
   validates :previous_work_experience,:allow_blank => true, numericality: { only_integer: true }
 
@@ -29,6 +32,16 @@ class PrivateProfile
       user.assign_leave('DOJ Updated') if user.eligible_for_leave?
       user.set_details("doj", self.date_of_joining)
     end
+  end
+
+  def validate_internship_date
+    errors.add(:internship_end_date, 'should be greater than internship start date.') if check_internship_start_end_date?
+  end
+
+  def check_internship_start_end_date?
+    internship_start_date.present? &&
+    internship_end_date.present? &&
+    internship_start_date > internship_end_date
   end
 
   def check_status_and_role?

--- a/app/views/users/_private_profile.html.haml
+++ b/app/views/users/_private_profile.html.haml
@@ -12,8 +12,14 @@
       %td
         = pri.input :qualification
     %tr
+      - disable = !( can? :edit, User )
       %td
-        - disable = ( can? :edit, User ) ? false : true
+        = pri.input :internship_start_date, disabled: disable, input_html: { type: 'date', class: 'date-picker', value: @private_profile.internship_start_date.try(:strftime, "%Y-%m-%d")}
+      %td
+        = pri.input :internship_end_date, disabled: disable, input_html: { type: 'date', class: 'date-picker', value: @private_profile.internship_end_date.try(:strftime, "%Y-%m-%d")}
+    %tr
+      %td
+        - disable = !( can? :edit, User )
         = pri.input :date_of_joining, disabled: disable, input_html: { type: 'date', class: 'date-picker', value: @private_profile.date_of_joining.try(:strftime, "%Y-%m-%d")}
         - if can? :edit, User
           = pri.input :end_of_probation, input_html: { type: 'date', class: 'date-picker', value: @private_profile.end_of_probation.try(:strftime, "%Y-%m-%d")}, label: 'End of probation (Date after 90 days)'

--- a/spec/models/employee_detail_spec.rb
+++ b/spec/models/employee_detail_spec.rb
@@ -5,7 +5,47 @@ describe EmployeeDetail do
   it { should belong_to(:designation) }
 
   context 'validations' do
+    let!(:user) { FactoryGirl.create(:user) }
     it { should validate_presence_of(:location) }
     it { is_expected.to validate_inclusion_of(:division).to_allow(DIVISION_TYPES.values) }
+
+    before do
+      @private_profile = user.private_profile
+      @employee_detail = user.employee_detail
+    end
+
+    it 'sholud be greter than date of joining' do
+      @private_profile.date_of_joining = Date.tomorrow
+      @employee_detail.date_of_relieving = Date.today
+      expect(user.valid?).to be_falsy
+      expect(@employee_detail.errors.full_messages).to eq(
+        ['Date of relieving should be greater than date of joining.']
+      )
+    end
+
+    it 'should pass because date of relieving is past date' do
+      @private_profile.date_of_joining = Date.today
+      @employee_detail.date_of_relieving = Date.tomorrow
+      expect(user.valid?).to_not be_falsy
+    end
+
+    it 'sholud be greter than Internship Start Date' do
+      user.role = 'Intern'
+      @private_profile.internship_start_date = Date.tomorrow
+      @private_profile.internship_end_date = Date.tomorrow + 1
+      @employee_detail.date_of_relieving = Date.today
+      expect(user.valid?).to be_falsy
+      expect(@employee_detail.errors.full_messages).to eq(
+        ['Date of relieving should be greater than Internship Start Date.']
+      )
+    end
+
+    it 'should pass because internship end date is past date' do
+      user.role = 'Intern'
+      @private_profile.date_of_joining = Date.today
+      @employee_detail.date_of_relieving = Date.tomorrow
+      @private_profile.internship_end_date = Date.tomorrow + 2
+      expect(user.valid?).to_not be_falsy
+    end
   end
 end

--- a/spec/models/private_profile_spec.rb
+++ b/spec/models/private_profile_spec.rb
@@ -112,4 +112,28 @@ describe PrivateProfile do
     end
   end
 
+  context 'validate_internship_date' do
+    let!(:user) { FactoryGirl.create(:user, role: 'Intern') }
+
+    before do
+      @private_profile = user.private_profile
+      @employee_detail = user.employee_detail
+    end
+
+    it 'sholud be greater than intrnship start date' do
+      @private_profile.internship_start_date = Date.tomorrow
+      @private_profile.internship_end_date = Date.today
+      expect(user.valid?).to be_falsy
+      expect(@private_profile.errors.full_messages).to eq(
+        ['Internship end date should be greater than internship start date.']
+      )
+    end
+
+    it 'should pass because internship end date is past date' do
+      @private_profile.internship_start_date = Date.today
+      @private_profile.internship_end_date = Date.tomorrow
+      expect(user.valid?).to_not be_falsy
+    end
+  end
+
 end


### PR DESCRIPTION
Validation of Internship date
1. InternShip end date should be greater than the internship start date.
2. InternShip relieving date should be greater than the internship start date.
3. Emp relieving date should be greater than the date of joining.