### PR TITLE
change the subject of automated leave email.

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -36,7 +36,7 @@ class UserMailer < ActionMailer::Base
 
   def accept_leave(leave_application_id)
     get_leave(leave_application_id)
-    mail(to: @notification_emails, subject: "Congrats! #{@leave_type} Request got accepted")
+    mail(to: @notification_emails, subject: "Your #{@leave_type} request is been approved")
   end
 
   def send_accept_leave_notification(leave_id, emails)

--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -36,7 +36,7 @@ class UserMailer < ActionMailer::Base
 
   def accept_leave(leave_application_id)
     get_leave(leave_application_id)
-    mail(to: @notification_emails, subject: "Your #{@leave_type} request is been approved")
+    mail(to: @notification_emails, subject: "Your #{@leave_type} request has been approved")
   end
 
   def send_accept_leave_notification(leave_id, emails)


### PR DESCRIPTION
 change the wordings of the subject of an automated email that comes once leave is approved. 
"Congrats! Leave Request got accepted" instead of this, we want simple text saying "Your leave request is been approved"
