### PR TITLE
 MODIFICATION - RSpec - Resource-Employee

### DIFF
--- a/spec/services/resource_categorisation_service_spec.rb
+++ b/spec/services/resource_categorisation_service_spec.rb
@@ -236,7 +236,7 @@ RSpec.describe ResourceCategorisationService do
       ActionMailer::Base.deliveries = []
       @service.call
       expect(ActionMailer::Base.deliveries.count).to eq(1)
-      expect(ActionMailer::Base.deliveries.first.subject).to eq("Resource Categorisation Report - #{Date.today}")
+      expect(ActionMailer::Base.deliveries.first.subject).to eq("Employee Categorisation Report - #{Date.today}")
     end
   end
 end


### PR DESCRIPTION
 RSpec file of Resource Categorization
 - Change of word Resource to Employee
 - fixes RSpec failures of changes made in PR#574 
 - https://github.com/joshsoftware/intranet/pull/574