### PR TITLE
  Feature - Current Project List in Leave Request Mail

### DIFF
--- a/app/mailers/user_mailer.rb
+++ b/app/mailers/user_mailer.rb
@@ -18,6 +18,7 @@ class UserMailer < ActionMailer::Base
 
   def leave_application(sender_email, receivers, leave_application_id)
     @user = User.find_by(email: sender_email)
+    @projects = @user.projects.map(&:name)
     @receivers = receivers
     @notification_names = @user.employee_detail.present? ? @user.employee_detail.get_notification_names : []
     @older_leaves = LeaveApplication.get_users_past_leaves(@user.id)

--- a/app/views/user_mailer/leave_application.html.haml
+++ b/app/views/user_mailer/leave_application.html.haml
@@ -88,6 +88,14 @@
                                                       %br/
                                                       Notification To: #{@notification_names.join(', ')}
                                                       %br
+                                                      %br
+                                                      - if @projects.length>0
+                                                        Here is the list of your projects:                                                       
+                                                        - @projects.each_with_index do |project, index|
+                                                          %br
+                                                          #{index + 1}. #{project}
+                                                      - else
+                                                        No Projects Assigned                                           
                                                       - if @older_leaves && @older_leaves.count > 0
                                                         %h4 Previously Approved Leaves
                                                         %table{:border => '1px solid black;', :style => 'border-collapse: collapse;', :width => '600'}

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -318,6 +318,27 @@ describe UsersController do
     end
   end
 
+  context '#leave_application mailing' do
+    before(:each) do
+      @sender = FactoryGirl.create(:user, email: 'test@joshsoftware.com')
+      @hr = FactoryGirl.create(:hr)
+      @leave_application = FactoryGirl.create(:leave_application, user: @sender)
+      sign_in @hr
+      ActionMailer::Base.deliveries = []
+    end
+
+    it 'should send mail to HR after an employee - Request Leave' do
+      Sidekiq::Testing.inline! do
+        sender_email = @sender.email
+        receiver_email = @hr.email
+        leave_application_id = @leave_application.id
+      
+        UserMailer.delay.leave_application(sender_email, receiver_email, leave_application_id)
+
+        expect(ActionMailer::Base.deliveries.count).to eq(1)
+      end
+    end
+  end
   ##Code is changed for downloading excel sheet, searching & pagination
   # context 'download excel sheet of Employee' do
   #   let!(:userlist) { FactoryGirl.create_list(:user, 4, status: STATUS[:approved]) }


### PR DESCRIPTION
   After "Nomination To: field" added "Current Projects list"
   - This feature will show modifications in the Leave Request Mail body.
   - All the active project the current employee is a part of will be listed.
   - Added RSpec test case for checking if mail is sent on Leave Request.