### PR TITLE
fix edit leave: re-direction path

### DIFF
--- a/app/controllers/leave_applications_controller.rb
+++ b/app/controllers/leave_applications_controller.rb
@@ -41,7 +41,7 @@ class LeaveApplicationsController < ApplicationController
       flash[:error] = @leave_application.errors.full_messages.join("\n")
       render 'edit' and return
     end
-    redirect_to ((can? :manage, LeaveApplication) ? leave_applications_path : view_leaves_path) and return
+    redirect_to view_leaves_path and return
   end
 
   def view_leave_status


### PR DESCRIPTION
Fix Bug:
Edit the leave and after successful changes, it landed on the Mange_leave page, ideally should be re-directing to the leaves list page.