### PR TITLE
Allow access to finances for users profile edit

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -10,7 +10,8 @@ class Ability
     elsif user.role? 'HR'
       hr_abilities(user.id)
     elsif user.role? 'Finance'
-      can [:public_profile, :private_profile, :apply_leave, :users_optional_holiday_list], User, id: user.id
+      can :edit, User
+      can [:public_profile, :private_profile, :apply_leave, :users_optional_holiday_list], User
       can [:projects_report, :export_project_report], TimeSheet
       can [:individual_project_report], [TimeSheet, Project]
       can :read, :dashboard

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -172,7 +172,7 @@ class User
   end
 
   def can_edit_user?(user)
-    ([ROLE[:HR], ROLE[:admin], ROLE[:manager], ROLE[:super_admin]].include?(self.role)) || self == user
+    ([ROLE[:HR], ROLE[:admin], ROLE[:manager], ROLE[:super_admin], ROLE[:finance]].include?(self.role)) || self == user
   end
 
   def can_download_document?(user, attachment)


### PR DESCRIPTION
As of now, finance does not have access to the employee profiles.
due to that, finance won't be able to see the finance tab which we are going to add to the employee profile.