### PR TITLE
Delete Leave Applications for Resigned Employee

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -38,6 +38,7 @@ class UsersController < ApplicationController
     if return_value_of_add_project && return_value_of_remove_project
       tab = params[:user][:attachments_attributes].present? ? 'Documents': 'Employee details'
       if @user.save
+        @user.reject_pending_and_wfh_leaves if @user.status == 'resigned'
         flash.notice = "#{tab} updated Successfully"
         redirect_to public_profile_user_path(@user)
       else

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -166,6 +166,10 @@ class User
     UserMailer.delay.leave_application(self.email, notified_users, leave_application_id)
   end
 
+  def reject_pending_and_wfh_leaves
+    self.leave_applications(:leave_type.in => ["PENDING", "WFH"]).delete_all
+  end
+
   def role?(role)
     self.role == role
   end


### PR DESCRIPTION
- Added Function in user.rb to delete available WFH and Pending leave_applications.
- Call the function in the users_controller.

Trello Tickets: https://trello.com/c/INoo0RZA/202-delete-pending-and-wfh-leaves-when-employees-gets-resigned